### PR TITLE
Fix framework references removing System reference (NuGet/Home#1880)

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks.Tests/NuGetTestHelpers.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/NuGetTestHelpers.cs
@@ -67,7 +67,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                 var references = task.ResolvedReferences;
                 var referencedPackages = task.ReferencedPackages;
 
-                return new ResolvePackagesResult(analyzers, copyLocalItems, references, referencedPackages);
+                return new ResolvePackagesResult(analyzers, copyLocalItems, references, referencedPackages, rootDirectory.Root);
             }
         }
     }

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ResolvePackagesResult.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ResolvePackagesResult.cs
@@ -21,17 +21,28 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
             ITaskItem[] analyzers,
             ITaskItem[] copyLocalItems,
             ITaskItem[] references,
-            ITaskItem[] referencedPackages)
+            ITaskItem[] referencedPackages,
+            string referenceTemporaryPath)
         {
             Analyzers = analyzers ?? new ITaskItem[] { };
             CopyLocalItems = copyLocalItems ?? new ITaskItem[] { };
             References = references ?? new ITaskItem[] { };
             ReferencedPackages = referencedPackages ?? new ITaskItem[] { };
+            ReferenceTemporaryPath = referenceTemporaryPath;
         }
 
         public ITaskItem[] Analyzers { get; }
         public ITaskItem[] CopyLocalItems { get; }
         public ITaskItem[] References { get; }
         public ITaskItem[] ReferencedPackages { get; }
+
+
+        /// <summary>
+        /// Gets the temporary path created during testing process
+        /// </summary>
+        /// <remarks>
+        /// You must assume this path no longer exists on disk, and can only be used to form absolute paths that match items in this object from relative paths
+        /// </remarks>
+        public string ReferenceTemporaryPath { get; }
     }
 }

--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -140,14 +140,15 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Remove exact references, such as if a package had a framework reference to 'System' that we already have -->
       <Reference Remove="@(_ReferencesFromNuGetPackages)" />
 
-      <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
-           consider a project with an Reference Include="System", and some NuGet package is providing System.dll -->
-      <Reference Remove="%(_ReferencesFromNuGetPackages.FileName)" />
-
       <!-- Remove simple name references that are already implicitly added -->
       <_ReferencesFromNuGetPackages Remove="%(ReferencePath.FileName)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandTargetFramework'" />
 
+      <!-- Include NuGet references -->
       <Reference Include="@(_ReferencesFromNuGetPackages)" />
+
+      <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
+           consider a project with an Reference Include="System", and some NuGet package is providing System.dll -->
+      <Reference Remove="%(_ReferencesFromNuGetPackages.FileName)" Condition="'%(_ReferencesFromNuGetPackages.NuGetIsFrameworkReference)' == 'false'"/>
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(AutoUnifyAssemblyReferences)' == 'true' ">

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -21,6 +21,7 @@ namespace Microsoft.NuGet.Build.Tasks
     {
         internal const string NuGetPackageIdMetadata = "NuGetPackageId";
         internal const string NuGetPackageVersionMetadata = "NuGetPackageVersion";
+        internal const string NuGetIsFrameworkReference = "NuGetIsFrameworkReference";
         internal const string ReferenceImplementationMetadata = "Implementation";
         internal const string ReferenceImageRuntimeMetadata = "ImageRuntime";
         internal const string ReferenceWinMDFileMetadata = "WinMDFile";
@@ -254,7 +255,9 @@ namespace Microsoft.NuGet.Build.Tasks
 
             foreach (var frameworkReference in frameworkReferences.Except(fileNamesOfRegularReferences, StringComparer.OrdinalIgnoreCase))
             {
-                _references.Add(new TaskItem(frameworkReference));
+                var item = new TaskItem(frameworkReference);
+                item.SetMetadata(NuGetIsFrameworkReference, "true");
+                _references.Add(item);
             }
         }
 
@@ -740,6 +743,7 @@ namespace Microsoft.NuGet.Build.Tasks
                 var item = CreateItem(package, package.GetFullPathToFile(file.Name), targetPath);
 
                 item.SetMetadata("Private", "false");
+                item.SetMetadata(NuGetIsFrameworkReference, "false");
 
                 items.Add(item);
             }


### PR DESCRIPTION
To fix NuGet/Home#1880

Just been bitten by this bug while trying to move to using csproj and *.project.json together on some projects. Don't know if this is being fixed internally, but thought I would share my solution.

Instead of trying to detect reference packages in the msbuild target by a heuristic like checking file extensions, which is bound to have subtle edge cases, I've gone the route of explicitly tagging the various references with a metadata flag that indicates whether or not the reference came from resolved package DLLs or from a framework reference, since we know this for certain while in the ResolveNuGetPackageAssets task.

I've then split out the inclusion of reference and exact references in the MSBuild script, hopefully retaining the exact behaviour as before minus the erroneous reference removal. Unfortunately I couldn't see any way to properly test the MSBuild target in the test project (only the task), and I didn't want to presume to write that kind of thing for such a small bug fix!

Let me know if more tests are needed, I realise the two I wrote are probably a little thin on the ground.