### PR TITLE
Include PDBs in copy local output

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks.Tests/AnalyzerResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/AnalyzerResolutionTests.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using Xunit;
-using static System.Text.Encoding;
 
 namespace Microsoft.NuGet.Build.Tasks.Tests
 {
@@ -13,7 +12,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestAnalyzerResolutionCSharp()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.analyzers),
+                Json.Json.analyzers,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "",
                 projectLanguage: "C#");
@@ -25,7 +24,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestAnalyzerResolutionVisualBasic()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.analyzers),
+                Json.Json.analyzers,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "",
                 projectLanguage: "vb");

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/AssertHelpers.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/AssertHelpers.cs
@@ -26,12 +26,26 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         /// </summary>
         public static void PathEndsWith(string expectedPath, string actualPath)
         {
-            if (expectedPath != actualPath)
+            // We could implement this with a simple Assert.True(...EndsWithPath),
+            // but that results in less user-friendly output from the test than a smarter call to
+            // Assert.EndsWith
+            if (!actualPath.EndsWithPath(expectedPath))
             {
-                // This means it must be a subfolder, so we have to prefix with a path component to ensure
-                // we are matching full components
                 Assert.EndsWith("\\" + expectedPath, actualPath);
+
+                // If we get out of sync with this function or EndsWithPath, that Assert might not
+                // fail. In that case, fail the test.
+                throw new Exception("The Assert.EndsWith in the previous line should have failed.");
             }
+        }
+
+        /// <summary>
+        /// Returns that the expected path ends with our actual path. "Ends with" in this case is defined by path
+        /// components, so "Directory\File" doesn't end with "ile", to prevent any bugs where path components get mangled.
+        /// </summary>
+        public static bool EndsWithPath(this string path, string suffix)
+        {
+            return path == suffix || path.EndsWith("\\" + suffix);
         }
 
         public static void AssertNoTargetPaths(IEnumerable<ITaskItem> items)

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.Designer.cs
@@ -61,72 +61,184 @@ namespace Microsoft.NuGet.Build.Tasks.Tests.Json {
         }
         
         /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: -9996,
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETCore,Version=v5.0&quot;: {
+        ///      &quot;Microsoft.AnalyzerPowerPack/1.0.0&quot;: {
+        ///        &quot;frameworkAssemblies&quot;: [
+        ///          &quot;System&quot;
+        ///        ]
+        ///    },
+        ///      &quot;Microsoft.CodeAnalysis.Analyzers/1.0.0&quot;: {
+        ///        &quot;frameworkAssemblies&quot;: [
+        ///          &quot;System&quot;
+        ///        ]
+        ///},
+        ///      &quot;System.Runtime.Analyzers/1.0.0&quot;: {
+        ///        &quot;frameworkAssemblies&quot;: [
+        ///          &quot;System&quot;
+        ///        ]
+        ///      },
+        ///      &quot;System.Runtime.InteropServices.Analyzers/1.0.0&quot;: {
+        ///     [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static byte[] analyzers {
+        internal static string analyzers {
             get {
-                object obj = ResourceManager.GetObject("analyzers", resourceCulture);
-                return ((byte[])(obj));
+                return ResourceManager.GetString("analyzers", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: 1,
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETFramework,Version=v4.5.2&quot;: {
+        ///      &quot;FluentAssertions/3.4.1&quot;: {
+        ///        &quot;frameworkAssemblies&quot;: [
+        ///          &quot;System.Xml&quot;,
+        ///          &quot;System.Xml.Linq&quot;
+        ///        ],
+        ///        &quot;compile&quot;: {
+        ///          &quot;lib/net45/FluentAssertions.Core.dll&quot;: {},
+        ///          &quot;lib/net45/FluentAssertions.dll&quot;: {}
+        ///        },
+        ///        &quot;runtime&quot;: {
+        ///          &quot;lib/net45/FluentAssertions.Core.dll&quot;: {},
+        ///          &quot;lib/net45/FluentAssertions.dll&quot;: {}
+        ///        }
+        ///      }
+        ///   [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static byte[] FluentAssertions {
+        internal static string FluentAssertions {
             get {
-                object obj = ResourceManager.GetObject("FluentAssertions", resourceCulture);
-                return ((byte[])(obj));
+                return ResourceManager.GetString("FluentAssertions", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: 1,
+        ///  &quot;targets&quot;: {
+        ///    &quot;UAP,Version=v10.0&quot;: {
+        ///      &quot;FluentAssertions/3.4.1&quot;: {
+        ///        &quot;frameworkAssemblies&quot;: [
+        ///          &quot;System.Xml&quot;,
+        ///          &quot;System.Xml.Linq&quot;
+        ///        ],
+        ///        &quot;compile&quot;: {
+        ///          &quot;lib/win8/FluentAssertions.Core.dll&quot;: {},
+        ///          &quot;lib/win8/FluentAssertions.dll&quot;: {}
+        ///        },
+        ///        &quot;runtime&quot;: {
+        ///          &quot;lib/win8/FluentAssertions.Core.dll&quot;: {},
+        ///          &quot;lib/win8/FluentAssertions.dll&quot;: {}
+        ///        }
+        ///      },
+        ///      &quot;Microsoft [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static byte[] FluentAssertionsAndWin10 {
+        internal static string FluentAssertionsAndWin10 {
             get {
-                object obj = ResourceManager.GetObject("FluentAssertionsAndWin10", resourceCulture);
-                return ((byte[])(obj));
+                return ResourceManager.GetString("FluentAssertionsAndWin10", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: 1,
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETCore,Version=v5.0&quot;: {
+        ///      &quot;Microsoft.NETCore.Platforms/1.0.0&quot;: {},
+        ///      &quot;Win2D/0.0.23-local&quot;: {
+        ///        &quot;compile&quot;: {
+        ///          &quot;lib/netcore50/Microsoft.Graphics.Canvas.winmd&quot;: {}
+        ///        },
+        ///        &quot;runtime&quot;: {
+        ///          &quot;lib/netcore50/Microsoft.Graphics.Canvas.winmd&quot;: {}
+        ///        }
+        ///      }
+        ///    },
+        ///    &quot;.NETCore,Version=v5.0/win10-arm&quot;: {
+        ///      &quot;Microsoft.NETCore.Platforms/1.0.0&quot;: {},
+        ///      &quot;Win2D/0.0.23-local&quot;: {
+        ///        &quot;compi [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static byte[] nativeWinMD {
+        internal static string nativeWinMD {
             get {
-                object obj = ResourceManager.GetObject("nativeWinMD", resourceCulture);
-                return ((byte[])(obj));
+                return ResourceManager.GetString("nativeWinMD", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: -9996,
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETCore,Version=v5.0&quot;: {
+        ///      &quot;Microsoft.ApplicationInsights/0.17.0&quot;: {
+        ///        &quot;compile&quot;: {
+        ///          &quot;lib/portable-win81+wpa81/Microsoft.ApplicationInsights.dll&quot;: {}
+        ///        },
+        ///        &quot;runtime&quot;: {
+        ///          &quot;lib/portable-win81+wpa81/Microsoft.ApplicationInsights.dll&quot;: {}
+        ///        }
+        ///      },
+        ///      &quot;Microsoft.ApplicationInsights.PersistenceChannel/0.17.0&quot;: {
+        ///        &quot;dependencies&quot;: {
+        ///          &quot;Microsoft.ApplicationInsights&quot;: &quot;0.1 [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static byte[] Win10 {
+        internal static string Win10 {
             get {
-                object obj = ResourceManager.GetObject("Win10", resourceCulture);
-                return ((byte[])(obj));
+                return ResourceManager.GetString("Win10", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: 1,
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETCore,Version=v5.0&quot;: {
+        ///      &quot;Microsoft.ApplicationInsights/1.0.0&quot;: {
+        ///        &quot;compile&quot;: {
+        ///          &quot;lib/portable-win81+wpa81/Microsoft.ApplicationInsights.dll&quot;: {}
+        ///        },
+        ///        &quot;runtime&quot;: {
+        ///          &quot;lib/portable-win81+wpa81/Microsoft.ApplicationInsights.dll&quot;: {}
+        ///        }
+        ///      },
+        ///      &quot;Microsoft.ApplicationInsights.PersistenceChannel/1.0.0&quot;: {
+        ///        &quot;dependencies&quot;: {
+        ///          &quot;Microsoft.ApplicationInsights&quot;: &quot;[1.0.0, ) [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static byte[] Win10_Edm {
+        internal static string Win10_Edm {
             get {
-                object obj = ResourceManager.GetObject("Win10_Edm", resourceCulture);
-                return ((byte[])(obj));
+                return ResourceManager.GetString("Win10_Edm", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: 1,
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETCore,Version=v5.0&quot;: {
+        ///      &quot;Microsoft.CSharp/4.0.0-beta-23106&quot;: {
+        ///        &quot;dependencies&quot;: {
+        ///          &quot;System.Runtime&quot;: &quot;[4.0.20-beta-23106, )&quot;,
+        ///          &quot;System.Runtime.InteropServices&quot;: &quot;[4.0.20-beta-23106, )&quot;,
+        ///          &quot;System.Resources.ResourceManager&quot;: &quot;[4.0.0-beta-23106, )&quot;,
+        ///          &quot;System.Dynamic.Runtime&quot;: &quot;[4.0.0-beta-23106, )&quot;,
+        ///          &quot;System.Linq.Expressions&quot;: &quot;[4.0.0-beta-23106, )&quot;,
+        ///          &quot;System.Linq&quot;: &quot;[4.0.0- [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static byte[] Win10_xunit {
+        internal static string Win10_xunit {
             get {
-                object obj = ResourceManager.GetObject("Win10_xunit", resourceCulture);
-                return ((byte[])(obj));
+                return ResourceManager.GetString("Win10_xunit", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
@@ -119,24 +119,24 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="analyzers" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>analyzers.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>analyzers.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="Win10" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Win10.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Win10.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="FluentAssertions" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>FluentAssertions.lock.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>FluentAssertions.lock.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="FluentAssertionsAndWin10" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>FluentAssertionsAndWin10.lock.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>FluentAssertionsAndWin10.lock.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="Win10_Edm" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Win10.Edm.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Win10.Edm.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="Win10_xunit" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>Win10.xunit.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>Win10.xunit.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="nativeWinMD" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>nativeWinMD.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>nativeWinMD.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
 </root>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -219,6 +219,21 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         }
 
         [Fact]
+        public static void CopyLocalContentsIncludePdbsIfAvailable()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Default.GetString(Json.Json.FluentAssertionsAndWin10),
+                targetMoniker: "UAP,Version=v10.0",
+                runtimeIdentifier: "win10-x86",
+                includeFrameworkReferences: true);
+
+            Assert.Single(result.CopyLocalItems, r => r.ItemSpec.EndsWithPath("FluentAssertions.dll"));
+            Assert.Single(result.CopyLocalItems, r => r.ItemSpec.EndsWithPath("FluentAssertions.pdb"));
+            Assert.Single(result.CopyLocalItems, r => r.ItemSpec.EndsWithPath("FluentAssertions.Core.dll"));
+            Assert.Single(result.CopyLocalItems, r => r.ItemSpec.EndsWithPath("FluentAssertions.Core.pdb"));
+        }
+
+        [Fact]
         public static void FrameworkReferencesAreNotProvidedIfAlreadyProvidedByAnotherPackage()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using Microsoft.NuGet.Build.Tasks;
 using Xunit;
-using static System.Text.Encoding;
 
 namespace Microsoft.NuGet.Build.Tasks.Tests
 {
@@ -16,7 +15,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestReferenceResolutionWithRuntimeIDWin10X86()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x86");
 
@@ -29,7 +28,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestReferenceResolutionWithRuntimeIDWin10X64()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x64");
 
@@ -42,7 +41,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestReferenceResolutionWithRuntimeIDWin10X86Aot()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x86-aot");
 
@@ -55,7 +54,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestReferenceResolutionWithRuntimeIDWin10X64Aot()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x64-aot");
 
@@ -68,7 +67,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestReferenceResolutionWithMissingRuntimeIDAndFallback()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "missing-runtime-identifier",
                 allowFallbackOnTargetSelection: true);
@@ -84,7 +83,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         {
             var exception = Assert.Throws<ExceptionFromResource>(() =>
                 NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                    Default.GetString(Json.Json.Win10),
+                    Json.Json.Win10,
                     targetMoniker: ".NETCore,Version=v5.0",
                     runtimeIdentifier: "missing-runtime-identifier",
                     allowFallbackOnTargetSelection: false));
@@ -98,7 +97,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         {
             var exception = Assert.Throws<ExceptionFromResource>(() =>
                 NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                    Default.GetString(Json.Json.Win10),
+                    Json.Json.Win10,
                     targetMoniker: ".NETCore,Version=v5.0",
                     runtimeIdentifier: "missing-runtime-identifier",
                     allowFallbackOnTargetSelection: false,
@@ -113,7 +112,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         {
             var exception = Assert.Throws<ExceptionFromResource>(() =>
                 NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                    Default.GetString(Json.Json.Win10),
+                    Json.Json.Win10,
                     targetMoniker: "Missing,Version=1.0",
                     runtimeIdentifier: "missing-runtime-identifier",
                     allowFallbackOnTargetSelection: false));
@@ -126,7 +125,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestReferenceResolutionWithMissingTargetFrameworkAndFallback()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: "MissingFrameworkMoniker,Version=v42.0",
                 runtimeIdentifier: "",
                 allowFallbackOnTargetSelection: true);
@@ -140,7 +139,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestReferenceResolutionWithNoRuntimeID()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "");
 
@@ -153,7 +152,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void PackagesHaveMetadataWithPackageIdAndVersion()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x86");
 
@@ -168,7 +167,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void ReferencedPackagesCorrectlyParsed()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10),
+                Json.Json.Win10,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "");
 
@@ -184,7 +183,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void ExcludingFrameworkReferencesActuallyExcludesFrameworkReferences()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.FluentAssertions),
+                Json.Json.FluentAssertions,
                 targetMoniker: ".NETFramework,Version=v4.5.2",
                 runtimeIdentifier: "",
                 includeFrameworkReferences: false);
@@ -202,7 +201,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void IncludingFrameworkReferencesActuallyIncludesFrameworkReferences()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.FluentAssertions),
+                Json.Json.FluentAssertions,
                 targetMoniker: ".NETFramework,Version=v4.5.2",
                 runtimeIdentifier: "",
                 includeFrameworkReferences: true);
@@ -222,7 +221,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void CopyLocalContentsIncludePdbsIfAvailable()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.FluentAssertionsAndWin10),
+                Json.Json.FluentAssertionsAndWin10,
                 targetMoniker: "UAP,Version=v10.0",
                 runtimeIdentifier: "win10-x86",
                 includeFrameworkReferences: true);
@@ -237,7 +236,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void FrameworkReferencesAreNotProvidedIfAlreadyProvidedByAnotherPackage()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.FluentAssertionsAndWin10),
+                Json.Json.FluentAssertionsAndWin10,
                 targetMoniker: "UAP,Version=v10.0",
                 runtimeIdentifier: "",
                 includeFrameworkReferences: true);
@@ -251,7 +250,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void AllNuGetReferencesHaveValidIsFrameworkReferenceProperty()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.FluentAssertions),
+                Json.Json.FluentAssertions,
                 targetMoniker: ".NETFramework,Version=v4.5.2",
                 runtimeIdentifier: "");
 
@@ -266,7 +265,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void AllReferencesHaveCorrectIsFrameworkReferenceProperty()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.FluentAssertions),
+                Json.Json.FluentAssertions,
                 targetMoniker: ".NETFramework,Version=v4.5.2",
                 runtimeIdentifier: "");
 
@@ -295,7 +294,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
             string imageRuntimeVersion = "WindowsRuntime 1.3";
             TryGetRuntimeVersion tryGetRuntimeVersion = p => imageRuntimeVersion;
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.nativeWinMD),
+                Json.Json.nativeWinMD,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x86",
                 tryGetRuntimeVersion: tryGetRuntimeVersion);
@@ -317,7 +316,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
             string imageRuntimeVersion = "WindowsRuntime 1.4;CLR v4.0.30319";
             TryGetRuntimeVersion tryGetRuntimeVersion = p => imageRuntimeVersion;
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.nativeWinMD),
+                Json.Json.nativeWinMD,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x86",
                 tryGetRuntimeVersion: tryGetRuntimeVersion);
@@ -338,7 +337,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
             string imageRuntimeVersion = "BogusRuntime 1.4;C1R v4.0.30319";
             TryGetRuntimeVersion tryGetRuntimeVersion = p => imageRuntimeVersion;
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.nativeWinMD),
+                Json.Json.nativeWinMD,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x86",
                 tryGetRuntimeVersion: tryGetRuntimeVersion);
@@ -357,7 +356,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestTargetPathCollisionsFound()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10_Edm),
+                Json.Json.Win10_Edm,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x86");
 
@@ -368,7 +367,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         public static void TestTargetPathCollisionsFound2()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
-                Default.GetString(Json.Json.Win10_xunit),
+                Json.Json.Win10_xunit,
                 targetMoniker: ".NETCore,Version=v5.0",
                 runtimeIdentifier: "win10-x86");
 

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -259,8 +259,8 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                 r => r.ItemSpec,
                 r => r.GetMetadata(ResolveNuGetPackageAssets.NuGetIsFrameworkReference)
             );
-            
-            Assert.Equal(4, references.Count);
+
+            AssertHelpers.AssertCountOf(4, result.References);
 
             var corePath = Path.Combine(result.ReferenceTemporaryPath, @"FluentAssertions\3.4.1\lib\net45\FluentAssertions.Core.dll");
             Assert.True(references.ContainsKey(corePath));


### PR DESCRIPTION
Including PDBs along copy local output is very useful. This matches the existing behavior of ResolveAssemblyReferences to put PDBs in the same output group (ReferenceCopyLocalItems) that we are.

*Review*: @NuGet/build-tasks-team, @onovotny