### PR TITLE
Condition mention of BeforeGenerateProjectPriFile only if needed

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -214,9 +214,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <NuGetTargetFrameworkMonikerToInject Condition="'$(NuGetTargetFrameworkMonikerToInject)' == ''">.NETCore,Version=v5.0</NuGetTargetFrameworkMonikerToInject>
     <NuGetTargetMonikerToInject Condition="'$(NuGetTargetMonikerToInject)' == ''">.NETCore,Version=v5.0</NuGetTargetMonikerToInject>
+    <_ComputeNetCoreFrameworkInjectionParametersBeforeTargets Condition="'$(AppxPackage)' == 'true' and '$(TargetPlatformIdentifier)' == 'UAP'">BeforeGenerateProjectPriFile</_ComputeNetCoreFrameworkInjectionParametersBeforeTargets>
   </PropertyGroup>
 
-  <Target Name="ComputeNetCoreFrameworkInjectionParameters" BeforeTargets="BeforeGenerateProjectPriFile" DependsOnTargets="_AddUnionWinmd" Condition="'$(AppxPackage)' == 'true' and '$(TargetPlatformIdentifier)' == 'UAP'">
+  <Target Name="ComputeNetCoreFrameworkInjectionParameters" BeforeTargets="$(_ComputeNetCoreFrameworkInjectionParametersBeforeTargets)" DependsOnTargets="_AddUnionWinmd" Condition="'$(_ComputeNetCoreFrameworkInjectionParametersBeforeTargets)' != ''">
     <PropertyGroup>
       <_PackagingOutputsIncludesFramework Condition="'%(PackagingOutputs.FileName)%(PackagingOutputs.Extension)' == 'System.Runtime.dll'">true</_PackagingOutputsIncludesFramework>
       <_AppContainsManagedCodeForInjection Condition="'%(PackagingOutputs.Identity)' == '$(_TargetPlatformSdkDir)UnionMetadata\Windows.winmd'">true</_AppContainsManagedCodeForInjection>


### PR DESCRIPTION
If you have a target that mentions another target in BeforeTargets,
but your target won't run, MSBuild still gives a warning. The workaround
is to condition the computation of BeforeTargets as well. There's a
bigger question here about where to move the .NET Core injection to,
since it's ugly that it lives here; I ignore that question for now.

Fixes NuGet/Home#1814.