### PR TITLE
Pass references from projects to ResolveAssemblyReferences.AssemblyFiles

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ProjectReferences/ProjectReferenceTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ProjectReferences/ProjectReferenceTests.cs
@@ -45,6 +45,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests.ProjectReferences
             Assert.Empty(result.Analyzers);
             AssertHelpers.PathEndsWith(@"XProjOutputDirectory\net452\XProjClassLib.dll", result.CopyLocalItems.Single().ItemSpec);
             AssertHelpers.PathEndsWith(@"XProjOutputDirectory\net452\XProjClassLib.dll", result.References.Single().ItemSpec);
+            Assert.All(result.References, r => Assert.Equal(ResolveNuGetPackageAssets.NuGetSourceType_Project, r.GetMetadata(ResolveNuGetPackageAssets.NuGetSourceType)));
             Assert.Empty(result.ReferencedPackages);
         }
 

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -218,6 +218,20 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
         }
 
         [Fact]
+        public static void AllPackageReferencesAreMarkedAsSuch()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.FluentAssertions,
+                targetMoniker: ".NETFramework,Version=v4.5.2",
+                runtimeIdentifier: "",
+                includeFrameworkReferences: true);
+
+            // We should have references to the package itself plus framework packages
+            AssertHelpers.AssertCountOf(4, result.References);
+            Assert.All(result.References, r => Assert.Equal(ResolveNuGetPackageAssets.NuGetSourceType_Package, r.GetMetadata(ResolveNuGetPackageAssets.NuGetSourceType)));
+        }
+
+        [Fact]
         public static void CopyLocalContentsIncludePdbsIfAvailable()
         {
             var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(

--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -164,8 +164,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <!-- Remove simple name references that are already implicitly added -->
       <_ReferencesFromNuGetPackages Remove="%(ReferencePath.FileName)" Condition="'%(ReferencePath.ResolvedFrom)' == 'ImplicitlyExpandTargetFramework'" />
 
-      <!-- Include NuGet references -->
-      <Reference Include="@(_ReferencesFromNuGetPackages)" />
+      <!-- Include NuGet references in the proper groups. Project-to-project references must go in the
+           _ResolvedProjectReferencePaths group which matches the behavior of the ResolveProjectReferences
+           target. This ensures that even if the assembly is missing on disk, it still makes it to the compiler. -->
+      <Reference Include="@(_ReferencesFromNuGetPackages)" Condition="'%(_ReferencesFromNuGetPackages.NuGetSourceType)' != 'Project'" />
+      <_ResolvedProjectReferencePaths Include="@(_ReferencesFromNuGetPackages)" Condition="'%(_ReferencesFromNuGetPackages.NuGetSourceType)' == 'Project'" />
 
       <!-- Remove simple name references if we're directly providing a reference assembly to the compiler. For example,
            consider a project with an Reference Include="System", and some NuGet package is providing System.dll -->

--- a/src/Microsoft.NuGet.Build.Tasks/NuGetPackageObject.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/NuGetPackageObject.cs
@@ -23,10 +23,11 @@ namespace Microsoft.NuGet.Build.Tasks
         /// </summary>
         private readonly Lazy<string> _fullPackagePath;
 
-        public NuGetPackageObject(string id, string version, Func<string> fullPackagePathGenerator, JObject targetObject, JObject libraryObject)
+        public NuGetPackageObject(string id, string version, bool isProject, Func<string> fullPackagePathGenerator, JObject targetObject, JObject libraryObject)
         {
             Id = id;
             Version = version;
+            IsProject = isProject;
             _fullPackagePath = new Lazy<string>(fullPackagePathGenerator);
             TargetObject = targetObject;
             LibraryObject = libraryObject;
@@ -34,6 +35,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
         public string Id { get; }
         public string Version { get; }
+        public bool IsProject { get; }
         
         /// <summary>
         /// The JSON object from the "targets" section in the project.lock.json for this package.


### PR DESCRIPTION
If we pass a full path to ResolveAssemblyReferences.Assemblies, it will
remove the file and not pass it along to the compiler. This is bad
for project-to-project references, since the Visual Studio IDE still
needs to know about them to make sure everything is wired up correctly.
With this, we now pass project-to-project references to AssemblyFiles,
matching the behavior of the ResolveProjectReferences target.

There is a deeper question of whether or not we should pass all our
full paths along to AssemblyFiles, but that's something which requires
fairly extensive testing and might have back-compat problems that need
to be dealt with.

Review: @NuGet/build-tasks-team 