### PR TITLE
Make the build task portable

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+
+<configuration>
+  <packageRestore>
+    <!-- Currently, the repository's version of NuGet.exe and Visual Studio's version
+         fight over the format of project.lock.json because the one in the respository
+         is newer. To prevent that, turn off package restore. -->
+    
+    <add key="automatic" value="false" />
+  </packageRestore>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+  <config>
+    <add key="repositoryPath" value="../packages" />
+  </config>
+  <packageSources>
+    <clear />
+    <add key="dotnet.myget.org msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+
+</configuration>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -9,12 +9,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.NuGet.Build.Tasks.Tests</RootNamespace>
     <AssemblyName>Microsoft.NuGet.Build.Tasks.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SignAssembly>true</SignAssembly>
     <PublicSign>true</PublicSign>
     <AssemblyOriginatorKeyFile>..\..\build\PublicKey.snk</AssemblyOriginatorKeyFile>
+    <IncludeFrameworkReferencesFromNuGet>false</IncludeFrameworkReferencesFromNuGet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,13 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="AnalyzerResolutionTests.cs" />
     <Compile Include="AssertHelpers.cs" />

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -95,6 +95,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/project.json
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/project.json
@@ -3,6 +3,10 @@
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },
-  "frameworks": { "net45": { } },
-  "runtimes": { "win": { } }
+  "frameworks": {
+    "net46": { }
+  },
+  "runtimes": {
+    "win": { }
+  }
 }

--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.Build.Tasks.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.Build.Tasks.csproj
@@ -9,12 +9,18 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.NuGet.Build.Tasks</RootNamespace>
     <AssemblyName>Microsoft.NuGet.Build.Tasks</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.0</NuGetTargetMoniker>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SignAssembly>true</SignAssembly>
     <PublicSign>true</PublicSign>
     <AssemblyOriginatorKeyFile>..\..\build\PublicKey.snk</AssemblyOriginatorKeyFile>
+    <NoStdLib>true</NoStdLib>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,13 +39,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Build.Framework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="Delegates.cs" />
     <Compile Include="ExceptionFromResource.cs" />
@@ -72,7 +71,7 @@
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
@@ -8,6 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using System.Reflection;
+
 namespace Microsoft.NuGet.Build.Tasks {
     using System;
     
@@ -39,7 +41,7 @@ namespace Microsoft.NuGet.Build.Tasks {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NuGet.Build.Tasks.Strings", typeof(Strings).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.NuGet.Build.Tasks.Strings", typeof(Strings).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
@@ -8,10 +8,9 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-using System.Reflection;
-
 namespace Microsoft.NuGet.Build.Tasks {
     using System;
+    using System.Reflection;
     
     
     /// <summary>

--- a/src/Microsoft.NuGet.Build.Tasks/project.json
+++ b/src/Microsoft.NuGet.Build.Tasks/project.json
@@ -1,5 +1,19 @@
 ﻿{
-  "dependencies": { "Newtonsoft.Json": "6.0.4" },
-  "frameworks": { "net45": { } },
-  "runtimes": { "win": { } }
+  "dependencies": {
+    "Microsoft.NETCore": "5.0.0",
+    "Microsoft.NETCore.Platforms": "1.0.0",
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
+    "Microsoft.Build.Framework": "0.1.0-preview-00005",
+    "Microsoft.Build.Tasks.Core": "0.1.0-preview-00005",
+    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00005",
+    "Newtonsoft.Json": "7.0.1"
+  },
+  "frameworks": {
+    "dotnet": {
+      "imports": "portable-net452"
+    }
+  },
+  "runtimes": {
+    "win": { }
+  }
 }

--- a/src/Microsoft.NuGet.Build.Tasks/project.json
+++ b/src/Microsoft.NuGet.Build.Tasks/project.json
@@ -1,19 +1,20 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore": "5.0.0",
-    "Microsoft.NETCore.Platforms": "1.0.0",
+    "Microsoft.Build.Framework": "14.0.0-preview01",
+    "Microsoft.Build.Tasks.Core": "14.0.0-preview01",
+    "Microsoft.Build.Utilities.Core": "14.0.0-preview01",
+    "Microsoft.CSharp": "4.0.1",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
-    "Microsoft.Build.Framework": "0.1.0-preview-00005",
-    "Microsoft.Build.Tasks.Core": "0.1.0-preview-00005",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00005",
-    "Newtonsoft.Json": "7.0.1"
+    "NETStandard.Library": "1.6.0",
+    "Newtonsoft.Json": "7.0.1",
+    "System.Diagnostics.Tools": "4.0.1"
   },
   "frameworks": {
-    "dotnet": {
-      "imports": "portable-net452"
+    "netstandard1.3": {
+      "imports": [
+        "portable-net452",
+        "dotnet"
+      ]
     }
-  },
-  "runtimes": {
-    "win": { }
   }
 }


### PR DESCRIPTION
This ports the build task from .NET desktop to .NET portable, able to run on both .NET 4.6 and coreclr.

However, the tests still need work to be converted. I don't expect this PR to be merged without changes to the tests.
