### PR TITLE
Gracefully handle broken lock file

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -73,6 +73,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Json\analyzers.json" />
     <None Include="Json\FluentAssertions.lock.json" />
     <None Include="Json\FluentAssertionsAndWin10.lock.json" />

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -13,7 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SignAssembly>true</SignAssembly>
-    <DelaySign>true</DelaySign>
+    <PublicSign>true</PublicSign>
     <AssemblyOriginatorKeyFile>..\..\build\PublicKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/app.config
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/app.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <appSettings>
+    <add key="xunit.shadowCopy" value="false"/>
+  </appSettings>
+</configuration>

--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.Build.Tasks.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.Build.Tasks.csproj
@@ -13,7 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SignAssembly>true</SignAssembly>
-    <DelaySign>true</DelaySign>
+    <PublicSign>true</PublicSign>
     <AssemblyOriginatorKeyFile>..\..\build\PublicKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -885,6 +885,11 @@ namespace Microsoft.NuGet.Build.Tasks
 
                 Func<string> fullPackagePathGenerator;
 
+                if (libraryObject == null)
+                {
+                    throw new ExceptionFromResource(nameof(Strings.MissingPackageInTargetsSection), package.Key);
+                }
+
                 // If this is a project then we need to figure out it's relative output path
                 if ((string)libraryObject["type"] == "project")
                 {

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.NuGet.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; could not be found in the libraries section of the lock file. This may indicate your lock file is corrupted..
+        /// </summary>
+        internal static string MissingPackageInTargetsSection {
+            get {
+                return ResourceManager.GetString("MissingPackageInTargetsSection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The project.json is referencing the project &apos;{0}&apos;, but an output path was not specified on an item in the {1} property..
         /// </summary>
         internal static string MissingProjectReference {

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -132,6 +132,9 @@
   <data name="MissingMSBuildPathInProjectPackage" xml:space="preserve">
     <value>Your project is consuming assets from the project '{0}' but no MSBuild project is found in the project.lock.json. Check the project references in your project file, and re-run NuGet restore.</value>
   </data>
+  <data name="MissingPackageInTargetsSection" xml:space="preserve">
+    <value>The package '{0}' could not be found in the libraries section of the lock file. This may indicate your lock file is corrupted.</value>
+  </data>
   <data name="MissingProjectReference" xml:space="preserve">
     <value>The project.json is referencing the project '{0}', but an output path was not specified on an item in the {1} property.</value>
   </data>


### PR DESCRIPTION
If we get a broken like file like we saw in NuGet/Home#2525, let's give a graceful error message instead of a NullReferenceException that's completely undebuggable.