### PR TITLE
Support reading package folder locations out of the lock file

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.Designer.cs
@@ -149,6 +149,34 @@ namespace Microsoft.NuGet.Build.Tasks.Tests.Json {
         /// <summary>
         ///   Looks up a localized string similar to {
         ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: 2,
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETFramework,Version=v4.5&quot;: {
+        ///      &quot;Newtonsoft.Json/8.0.3&quot;: {
+        ///        &quot;type&quot;: &quot;package&quot;,
+        ///        &quot;compile&quot;: {
+        ///          &quot;lib/net45/Newtonsoft.Json.dll&quot;: {}
+        ///        },
+        ///        &quot;runtime&quot;: {
+        ///          &quot;lib/net45/Newtonsoft.Json.dll&quot;: {}
+        ///        }
+        ///      }
+        ///    }
+        ///  },
+        ///  &quot;libraries&quot;: {
+        ///    &quot;Newtonsoft.Json/8.0.3&quot;: {
+        ///      &quot;sha512&quot;: &quot;KGsYQdS2zLH+H8x2cZaSI7e+YZ4SFIbyy1YJQYl6GYBWjf5o4H1A68nxyq+WTyVSOJQ4GqS/DiPE+UseUizgMg==&quot;,
+        ///      &quot;type&quot;: &quot; [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string LockFileWithWithSpecifiedPackageFolders {
+            get {
+                return ResourceManager.GetString("LockFileWithWithSpecifiedPackageFolders", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
         ///  &quot;version&quot;: 1,
         ///  &quot;targets&quot;: {
         ///    &quot;.NETCore,Version=v5.0&quot;: {

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
@@ -139,4 +139,7 @@
   <data name="nativeWinMD" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>nativeWinMD.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="LockFileWithWithSpecifiedPackageFolders" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>lockfilewithwithspecifiedpackagefolders.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/LockFileWithWithSpecifiedPackageFolders.json
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/LockFileWithWithSpecifiedPackageFolders.json
@@ -1,0 +1,52 @@
+{
+  "locked": false,
+  "version": 2,
+  "targets": {
+    ".NETFramework,Version=v4.5": {
+      "Newtonsoft.Json/8.0.3": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Newtonsoft.Json/8.0.3": {
+      "sha512": "KGsYQdS2zLH+H8x2cZaSI7e+YZ4SFIbyy1YJQYl6GYBWjf5o4H1A68nxyq+WTyVSOJQ4GqS/DiPE+UseUizgMg==",
+      "type": "package",
+      "path": "newtonsoft.json/8.0.3",
+      "files": [
+        "lib/net20/Newtonsoft.Json.dll",
+        "lib/net20/Newtonsoft.Json.xml",
+        "lib/net35/Newtonsoft.Json.dll",
+        "lib/net35/Newtonsoft.Json.xml",
+        "lib/net40/Newtonsoft.Json.dll",
+        "lib/net40/Newtonsoft.Json.xml",
+        "lib/net45/Newtonsoft.Json.dll",
+        "lib/net45/Newtonsoft.Json.xml",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.dll",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.xml",
+        "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll",
+        "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.xml",
+        "newtonsoft.json.8.0.3.nupkg.sha512",
+        "newtonsoft.json.nuspec",
+        "tools/install.ps1"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "Newtonsoft.Json"
+    ],
+    ".NETFramework,Version=v4.5": []
+  },
+  "tools": {},
+  "projectFileToolGroups": {},
+  "packageFolders": {
+    "C:\\PackageFolder\\": {}
+  }
+}

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -55,6 +55,7 @@
       <DependentUpon>Json.resx</DependentUpon>
     </Compile>
     <Compile Include="NuGetTestHelpers.cs" />
+    <Compile Include="PackageFolderTests.cs" />
     <Compile Include="PreprocessorTests.cs" />
     <Compile Include="ProjectReferences\ProjectReferenceTests.cs" />
     <Compile Include="ProjectReferences\Resources.Designer.cs">
@@ -78,6 +79,7 @@
     <None Include="Json\FluentAssertions.lock.json" />
     <None Include="Json\FluentAssertionsAndWin10.lock.json" />
     <None Include="Json\nativeWinMD.json" />
+    <None Include="Json\LockFileWithWithSpecifiedPackageFolders.json" />
     <None Include="Json\Win10.Edm.json" />
     <None Include="Json\Win10.json" />
     <None Include="Json\Win10.xunit.json" />

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/PackageFolderTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/PackageFolderTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.NuGet.Build.Tasks.Tests
+{
+    public class PackageFolderTests
+    {
+        [Fact]
+        public void ResolveWithLockFileWithPackageFolders()
+        {
+            var result = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.LockFileWithWithSpecifiedPackageFolders,
+                ".NETFramework,Version=v4.5",
+                runtimeIdentifier: null,
+                createTemporaryFolderForPackages: false);
+
+            Assert.Equal(@"C:\PackageFolder\Newtonsoft.Json\8.0.3\lib\net45\Newtonsoft.Json.dll", result.References.Single().ItemSpec);
+        }
+    }
+}

--- a/src/Microsoft.NuGet.Build.Tasks/Delegates.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/Delegates.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.NuGet.Build.Tasks
 {
-    internal delegate bool DirectoryExists(string path);
     internal delegate bool FileExists(string path);
     internal delegate string TryGetRuntimeVersion(string path);
 }

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -49,19 +49,13 @@ namespace Microsoft.NuGet.Build.Tasks
         private readonly Dictionary<string, string> _projectReferencesToOutputBasePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         #region UnitTestSupport
-        private readonly DirectoryExists _directoryExists = new DirectoryExists(Directory.Exists);
         private readonly FileExists _fileExists = new FileExists(File.Exists);
         private readonly TryGetRuntimeVersion _tryGetRuntimeVersion = new TryGetRuntimeVersion(TryGetRuntimeVersion);
         private readonly bool _reportExceptionsToMSBuildLogger = true;
 
-        internal ResolveNuGetPackageAssets(DirectoryExists directoryExists, FileExists fileExists, TryGetRuntimeVersion tryGetRuntimeVersion)
+        internal ResolveNuGetPackageAssets(FileExists fileExists, TryGetRuntimeVersion tryGetRuntimeVersion)
             : this()
         {
-            if (directoryExists != null)
-            {
-                _directoryExists = directoryExists;
-            }
-
             if (fileExists != null)
             {
                 _fileExists = fileExists;
@@ -894,7 +888,9 @@ namespace Microsoft.NuGet.Build.Tasks
             {
                 string packagePath = Path.Combine(packagesFolder, packageId, packageVersion);
 
-                if (_directoryExists(packagePath))
+                // The proper way to check if a package is available is to look for the hash file, since that's the last
+                // file written as a part of the restore process. If it's not there, it means something failed part way through.
+                if (_fileExists(Path.Combine(packagePath, $"{packageId}.{packageVersion}.nupkg.sha512")))
                 {
                     return packagePath;
                 }


### PR DESCRIPTION
The task previously was constructing the path to the user's packages
location itself, which had various issues. It meant that if the restore
was done with a different path, we don't know that. It also meant we
didn't handle the paths specified in nuget.config. Now, if the paths
are present in the lock file, we'll use that. Otherwise, we'll construct
our old path as before. Any explicitly given path to the task is
still used no matter what.

*Review:* @NuGet/build-tasks-team, @emgarten, @yishaigalatzer, @rrelyea