### PR TITLE
Adding SolutionFile ImportsAfter target

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.Solution.ImportAfter.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.Solution.ImportAfter.targets
@@ -1,0 +1,18 @@
+<!--
+***********************************************************************************************
+Microsoft.NuGet.Solution.ImportAfter.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Import NuGet.targets for solution Restore -->
+  <PropertyGroup>
+    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets</NuGetRestoreTargets>
+  </PropertyGroup>
+  <Import Condition="Exists('$(NuGetRestoreTargets)')" Project="$(NuGetRestoreTargets)" />
+</Project>


### PR DESCRIPTION
Adding targets file for ``SolutionFile\ImportsAfter``

This file should be added to ``SolutionFile\ImportsAfter`` for MSBuild desktop to enable ``msbuild /t:Restore solution.sln``

This has already been added to the CLI MSBuild.

The path to NuGet.targets matches the path used in the current ImportAfter targets files, and points to the NuGet VSIX.

https://github.com/Microsoft/msbuild/issues/920
https://github.com/NuGet/Home/issues/2993