### PR TITLE
Fix an issue in how we handle projectFileDependencyGroups

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.Designer.cs
@@ -177,6 +177,36 @@ namespace Microsoft.NuGet.Build.Tasks.Tests.Json {
         /// <summary>
         ///   Looks up a localized string similar to {
         ///  &quot;locked&quot;: false,
+        ///  &quot;version&quot;: 2,
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETFramework,Version=v4.5&quot;: {
+        ///      &quot;Newtonsoft.Json/8.0.3&quot;: {
+        ///        &quot;type&quot;: &quot;package&quot;,
+        ///        &quot;compile&quot;: {
+        ///          &quot;lib/net45/Newtonsoft.Json.dll&quot;: {}
+        ///        },
+        ///        &quot;runtime&quot;: {
+        ///          &quot;lib/net45/Newtonsoft.Json.dll&quot;: {}
+        ///        }
+        ///      }
+        ///    },
+        ///    &quot;.NETFramework,Version=v4.6&quot;: {
+        ///      &quot;FluentAssertions/3.4.1&quot;: {
+        ///        &quot;frameworkAssemblies&quot;: [
+        ///          &quot;System.Xml&quot;,
+        ///          &quot;System.Xml.Linq&quot;
+        ///        ],
+        ///        [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string MultipleProjectFileDependencyGroups {
+            get {
+                return ResourceManager.GetString("MultipleProjectFileDependencyGroups", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;locked&quot;: false,
         ///  &quot;version&quot;: 1,
         ///  &quot;targets&quot;: {
         ///    &quot;.NETCore,Version=v5.0&quot;: {

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/Json.resx
@@ -142,4 +142,7 @@
   <data name="LockFileWithWithSpecifiedPackageFolders" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>lockfilewithwithspecifiedpackagefolders.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="MultipleProjectFileDependencyGroups" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>multipleprojectfiledependencygroups.json;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
 </root>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Json/MultipleProjectFileDependencyGroups.json
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Json/MultipleProjectFileDependencyGroups.json
@@ -1,0 +1,150 @@
+{
+  "locked": false,
+  "version": 2,
+  "targets": {
+    ".NETFramework,Version=v4.5": {
+      "Newtonsoft.Json/8.0.3": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      }
+    },
+    ".NETFramework,Version=v4.6": {
+      "FluentAssertions/3.4.1": {
+        "frameworkAssemblies": [
+          "System.Xml",
+          "System.Xml.Linq"
+        ],
+        "compile": {
+          "lib/net45/FluentAssertions.Core.dll": {},
+          "lib/net45/FluentAssertions.dll": {}
+        },
+        "runtime": {
+          "lib/net45/FluentAssertions.Core.dll": {},
+          "lib/net45/FluentAssertions.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Newtonsoft.Json/8.0.3": {
+      "sha512": "KGsYQdS2zLH+H8x2cZaSI7e+YZ4SFIbyy1YJQYl6GYBWjf5o4H1A68nxyq+WTyVSOJQ4GqS/DiPE+UseUizgMg==",
+      "type": "package",
+      "path": "newtonsoft.json/8.0.3",
+      "files": [
+        "lib/net20/Newtonsoft.Json.dll",
+        "lib/net20/Newtonsoft.Json.xml",
+        "lib/net35/Newtonsoft.Json.dll",
+        "lib/net35/Newtonsoft.Json.xml",
+        "lib/net40/Newtonsoft.Json.dll",
+        "lib/net40/Newtonsoft.Json.xml",
+        "lib/net45/Newtonsoft.Json.dll",
+        "lib/net45/Newtonsoft.Json.xml",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.dll",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.xml",
+        "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll",
+        "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.xml",
+        "newtonsoft.json.8.0.3.nupkg.sha512",
+        "newtonsoft.json.nuspec",
+        "tools/install.ps1"
+      ]
+    },
+    "FluentAssertions/3.4.1": {
+      "sha512": "GTyLzP7d57D3HLVOSFrTSVwod3rZNQRMC2DR13u1hNNyhsskLrbI4SW5XXqyEv8WP7v8IqWx9hdlDiwLY0G8YA==",
+      "type": "Package",
+      "files": [
+        "_rels/.rels",
+        "FluentAssertions.nuspec",
+        "lib/net40/FluentAssertions.Core.dll",
+        "lib/net40/FluentAssertions.Core.pdb",
+        "lib/net40/FluentAssertions.Core.xml",
+        "lib/net40/FluentAssertions.dll",
+        "lib/net40/FluentAssertions.pdb",
+        "lib/net40/FluentAssertions.xml",
+        "lib/net45/FluentAssertions.Core.dll",
+        "lib/net45/FluentAssertions.Core.pdb",
+        "lib/net45/FluentAssertions.Core.xml",
+        "lib/net45/FluentAssertions.dll",
+        "lib/net45/FluentAssertions.pdb",
+        "lib/net45/FluentAssertions.xml",
+        "lib/portable-monotouch+monoandroid+xamarin.ios/FluentAssertions.Core.dll",
+        "lib/portable-monotouch+monoandroid+xamarin.ios/FluentAssertions.Core.pdb",
+        "lib/portable-monotouch+monoandroid+xamarin.ios/FluentAssertions.Core.xml",
+        "lib/portable-net40+sl5+win8+wp8+wpa81/FluentAssertions.Core.dll",
+        "lib/portable-net40+sl5+win8+wp8+wpa81/FluentAssertions.Core.pdb",
+        "lib/portable-net40+sl5+win8+wp8+wpa81/FluentAssertions.Core.xml",
+        "lib/portable-net40+sl5+win8+wp8+wpa81/FluentAssertions.dll",
+        "lib/portable-net40+sl5+win8+wp8+wpa81/FluentAssertions.pdb",
+        "lib/portable-net40+sl5+win8+wp8+wpa81/FluentAssertions.XML",
+        "lib/portable-win81+wpa81/FluentAssertions.Core.dll",
+        "lib/portable-win81+wpa81/FluentAssertions.Core.pdb",
+        "lib/portable-win81+wpa81/FluentAssertions.Core.xml",
+        "lib/portable-win81+wpa81/FluentAssertions.dll",
+        "lib/portable-win81+wpa81/FluentAssertions.pdb",
+        "lib/portable-win81+wpa81/FluentAssertions.xml",
+        "lib/sl5/FluentAssertions.Core.dll",
+        "lib/sl5/FluentAssertions.Core.pdb",
+        "lib/sl5/FluentAssertions.Core.xml",
+        "lib/sl5/FluentAssertions.dll",
+        "lib/sl5/FluentAssertions.pdb",
+        "lib/sl5/FluentAssertions.xml",
+        "lib/sl5/Microsoft.CSharp.dll",
+        "lib/sl5/Microsoft.CSharp.xml",
+        "lib/sl5/Microsoft.VisualStudio.QualityTools.UnitTesting.Silverlight.dll",
+        "lib/sl5/Microsoft.VisualStudio.QualityTools.UnitTesting.Silverlight.xml",
+        "lib/sl5/System.Xml.Linq.dll",
+        "lib/sl5/System.Xml.Linq.xml",
+        "lib/sl5/de/Microsoft.CSharp.resources.dll",
+        "lib/sl5/de/System.Xml.Linq.resources.dll",
+        "lib/sl5/es/Microsoft.CSharp.resources.dll",
+        "lib/sl5/es/System.Xml.Linq.resources.dll",
+        "lib/sl5/fr/Microsoft.CSharp.resources.dll",
+        "lib/sl5/fr/System.Xml.Linq.resources.dll",
+        "lib/sl5/it/Microsoft.CSharp.resources.dll",
+        "lib/sl5/it/System.Xml.Linq.resources.dll",
+        "lib/sl5/ja/Microsoft.CSharp.resources.dll",
+        "lib/sl5/ja/System.Xml.Linq.resources.dll",
+        "lib/sl5/ko/Microsoft.CSharp.resources.dll",
+        "lib/sl5/ko/System.Xml.Linq.resources.dll",
+        "lib/sl5/ru/Microsoft.CSharp.resources.dll",
+        "lib/sl5/ru/System.Xml.Linq.resources.dll",
+        "lib/sl5/zh-Hans/Microsoft.CSharp.resources.dll",
+        "lib/sl5/zh-Hans/System.Xml.Linq.resources.dll",
+        "lib/sl5/zh-Hant/Microsoft.CSharp.resources.dll",
+        "lib/sl5/zh-Hant/System.Xml.Linq.resources.dll",
+        "lib/win8/FluentAssertions.Core.dll",
+        "lib/win8/FluentAssertions.Core.pdb",
+        "lib/win8/FluentAssertions.Core.xml",
+        "lib/win8/FluentAssertions.dll",
+        "lib/win8/FluentAssertions.pdb",
+        "lib/win8/FluentAssertions.XML",
+        "lib/wp8/FluentAssertions.Core.dll",
+        "lib/wp8/FluentAssertions.Core.pdb",
+        "lib/wp8/FluentAssertions.Core.xml",
+        "lib/wp8/FluentAssertions.dll",
+        "lib/wp8/FluentAssertions.pdb",
+        "lib/wp8/FluentAssertions.xml",
+        "package/services/metadata/core-properties/c21a09dd42de4a6295af89109b879195.psmdcp",
+        "[Content_Types].xml"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [],
+    ".NETFramework,Version=v4.5": [
+        "Newtonsoft.Json >= 8.0.1"
+    ],
+    ".NETFramework,Version=v4.6": [
+        "FluentAssertions >= 3.4.1"
+    ]
+  },
+  "tools": {},
+  "projectFileToolGroups": {},
+  "packageFolders": {
+    "C:\\PackageFolder\\": {}
+  }
+}

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -78,6 +78,7 @@
     <None Include="Json\analyzers.json" />
     <None Include="Json\FluentAssertions.lock.json" />
     <None Include="Json\FluentAssertionsAndWin10.lock.json" />
+    <None Include="Json\MultipleProjectFileDependencyGroups.json" />
     <None Include="Json\nativeWinMD.json" />
     <None Include="Json\LockFileWithWithSpecifiedPackageFolders.json" />
     <None Include="Json\Win10.Edm.json" />

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -397,17 +397,15 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                 runtimeIdentifier: "win",
                 allowFallbackOnTargetSelection: true);
 
-            AssertHelpers.AssertCountOf(1, resultFor45.ReferencedPackages);
-
             var packageNames = resultFor45.ReferencedPackages.Select(t => t.ItemSpec);
 
-            Assert.Contains("Newtonsoft.Json", packageNames);
+            Assert.Equal("Newtonsoft.Json", packageNames.Single());
 
             var resultFor46 = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
                 Json.Json.MultipleProjectFileDependencyGroups,
                 targetMoniker: ".NETFramework,Version=v4.6",
                 runtimeIdentifier: "win",
-                allowFallbackOnTargetSelection:true);
+                allowFallbackOnTargetSelection: true);
 
             AssertHelpers.AssertCountOf(1, resultFor46.ReferencedPackages);
 

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -387,5 +387,33 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
 
             AssertHelpers.AssertConsistentTargetPaths(result.CopyLocalItems);
         }
+
+        [Fact]
+        public static void MultipleProjectFileDependencyGroups()
+        {
+            var resultFor45 = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.MultipleProjectFileDependencyGroups,
+                targetMoniker: ".NETFramework,Version=v4.5",
+                runtimeIdentifier: "win",
+                allowFallbackOnTargetSelection: true);
+
+            AssertHelpers.AssertCountOf(1, resultFor45.ReferencedPackages);
+
+            var packageNames = resultFor45.ReferencedPackages.Select(t => t.ItemSpec);
+
+            Assert.Contains("Newtonsoft.Json", packageNames);
+
+            var resultFor46 = NuGetTestHelpers.ResolvePackagesWithJsonFileContents(
+                Json.Json.MultipleProjectFileDependencyGroups,
+                targetMoniker: ".NETFramework,Version=v4.6",
+                runtimeIdentifier: "win",
+                allowFallbackOnTargetSelection:true);
+
+            AssertHelpers.AssertCountOf(1, resultFor46.ReferencedPackages);
+
+            packageNames = resultFor46.ReferencedPackages.Select(t => t.ItemSpec);
+
+            Assert.Contains("FluentAssertions", packageNames);
+        }
     }
 }

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -905,12 +905,13 @@ namespace Microsoft.NuGet.Build.Tasks
         {
             foreach (var packageDependency in packageDependencies.Select(v => (string)v))
             {
+                // Strip the version, if any, from the dependency.
                 int firstSpace = packageDependency.IndexOf(' ');
+                string packageName = firstSpace > -1
+                    ? packageDependency.Substring(0, firstSpace)
+                    : packageDependency;
 
-                if (firstSpace > -1)
-                {
-                    _referencedPackages.Add(new TaskItem(packageDependency.Substring(0, firstSpace)));
-                }
+                _referencedPackages.Add(new TaskItem(packageName));
             }
         }
 


### PR DESCRIPTION
In order to show the set of referenced packages in the Solution Explorer the build task digs through the items in the "projectFileDependencyGroups" section of the project.lock.json/project.assets.json file. Currently, we assume all of the packages we care about will be in the subsection denoted by the empty string, "". It turns out that this is not true. This subsection may not exist at all, and when it does it only holds the set of packages common to all targets. Target-specific packages will be in target-specific subsections.

To fix this, we now try to look up the preferred target moniker and look up a subsection with that name. Then we add in the common packages.