### PR TITLE
Added RuntimeIdentifiers property for non-UAP projects for PackageReference

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -63,6 +63,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NuGetRuntimeIdentifier Condition="'$(UseDotNetNativeToolchain)' == 'true'">$(_NuGetRuntimeIdentifierWithoutAot)-aot</NuGetRuntimeIdentifier>
   </PropertyGroup>
 
+  <!-- If RuntimeIdentifiers weren't already specified for non-UAP projects, then generate it -->
+  <PropertyGroup Condition="'$(BaseNuGetRuntimeIdentifier)' == 'win' and '$(NuGetRuntimeIdentifier)' != '' and '$(RuntimeIdentifiers)' == '' and '$(RuntimeIdentifier)' == ''">
+    <RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- If we are resolving from project.lock.json, we need to consider any edit to it as something that forces a rebuild -->
     <CustomAdditionalCompileInputs Include="$(ProjectLockFile)" Condition="'$(ResolveNuGetPackages)' == 'true' and Exists('$(ProjectLockFile)')" />


### PR DESCRIPTION
Added RuntimeIdentifiers property for non-UAP projects for PackageReference scenarios inside Microsoft.NuGet.Targets file. For UAP projects, It's already being handled by UAP team.

Fixes https://github.com/NuGet/Home/issues/4030
 
@rrelyea @emgarten @jasonmalinowski @tmeschter 