### PR TITLE
When no assets or lock file provided, fallback to project.assets.json file

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -29,6 +29,13 @@ Copyright (c) .NET Foundation. All rights reserved.
       </PropertyGroup>
     </When>
 
+    <When Condition="'$(RestoreProjectStyle)' == 'PackageReference'">
+      <!-- The RestoreProjectStyle property has been specified to PackageReference, so use that. -->
+      <PropertyGroup>
+        <ProjectLockFile>$(BaseIntermediateOutputPath)project.assets.json</ProjectLockFile>
+      </PropertyGroup>
+    </When>
+
     <When Condition="'$(ProjectLockFile)' != ''">
       <!-- The ProjectLockFile has been specified; don't compute it. -->
     </When>
@@ -46,6 +53,13 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectLockFile>project.lock.json</ProjectLockFile>
       </PropertyGroup>
     </When>
+
+    <Otherwise>
+      <!-- No assets or lock file provided at all, so fallback to project.assets.json file.-->
+      <PropertyGroup>
+        <ProjectLockFile>$(BaseIntermediateOutputPath)project.assets.json</ProjectLockFile>
+      </PropertyGroup>
+    </Otherwise>
   </Choose>
 
   <!-- Add to MSBuildAllProjects in order to better support incremental builds. -->


### PR DESCRIPTION
This PR added 2 additional conditions for project.assets.file:

1. When RestoreProjectStyle property is set to PackageReference then set ProjectLockFile to project.assets.json file
2. When there is no assets or lock file defined, then always fallback to project.assets.json file

Fixes https://github.com/NuGet/Home/issues/4267 internal bug# 366649 

@rrelyea @emgarten @tmeschter @jasonmalinowski @alpaix 