### PR TITLE
Add skip imports conditions to ImportBefore and ImportAfter props/targets

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets
@@ -13,7 +13,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <NuGetTargets Condition="'$(NuGetTargets)'==''">$(MSBuildExtensionsPath)\Microsoft\NuGet\$(VisualStudioVersion)\Microsoft.NuGet.targets</NuGetTargets>
   </PropertyGroup>
-  <Import Condition="Exists('$(NuGetTargets)')" Project="$(NuGetTargets)" />
+  <Import Condition="Exists('$(NuGetTargets)') and '$(SkipImportNuGetBuildTargets)' != 'true'" Project="$(NuGetTargets)" />
 
   <!-- Import NuGet.targets for Restore -->
   <PropertyGroup>

--- a/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportBefore.props
+++ b/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportBefore.props
@@ -13,5 +13,5 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <NuGetProps Condition="'$(NuGetProps)'==''">$(MSBuildExtensionsPath)\Microsoft\NuGet\$(VisualStudioVersion)\Microsoft.NuGet.props</NuGetProps>
   </PropertyGroup>
-  <Import Condition="Exists('$(NuGetProps)')" Project="$(NuGetProps)" />
+  <Import Condition="Exists('$(NuGetProps)') and '$(SkipImportNuGetProps)' != 'true'" Project="$(NuGetProps)" />
 </Project>


### PR DESCRIPTION
**Related PRs/Issues**

https://github.com/dotnet/roslyn-project-system/issues/1474
https://github.com/dotnet/roslyn-project-system/issues/1508

https://github.com/dotnet/sdk/pull/870
VS change: [PR 57278](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/Default/_git/VS/pullrequest/57278)

**Customer scenario**

Customers restoring projects with reference to certain packages (e.g. System.ValueTuple) will see hundreds of downgrade warnings, when they restore from Visual Studio. However they don't see those same warnings when restoring from the CLI.

The root cause is that the VS targets automatically import Microsoft.NuGet.targets, which contains legacy properties and targets associated with project.json. This targets file is specified as an automatic "ImportAfter" Microsoft.Common.targets for all project types. Other errors are sometimes reported because of the inclusion of this file (https://github.com/dotnet/roslyn-project-system/issues/1508). The downgrade warnings occur because more RIDs are restored than are specified because of this property in Microsoft.NuGet.targets: 
```xml
<RuntimeIdentifiers>win;win-x86;win-x64</RuntimeIdentifiers>
```

The CLI dropped this file from their version ImportAfter, however VS cannot drop it since it is used by other project types. This change adds some conditions allowing us to skip importing this file in .NET Core projects.

There are two parts to this fix:
- this VS side change which adds conditions to the imports: [PR 57278](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/Default/_git/VS/pullrequest/57278)
- an SDK PR sets the properties for .NET Core projects: https://github.com/dotnet/sdk/pull/870

**Bugs this fixes:**

https://github.com/dotnet/roslyn-project-system/issues/1474 and https://github.com/dotnet/roslyn-project-system/issues/1508

**Risk**

Low. The risk may come from us accidentally depending on properties defined in Microsoft.NuGet.targets but all relevant properties have already been copied over to our targets. Furthermore the CLI has been operating without a dependency on this for some time so this ensures parity between the VS and CLI experience.

**Performance impact**

None

**Is this a regression from a previous update?**

No

**How was the bug found?**

Dogfooding

/cc @emgarten 