### PR TITLE
Set RuntimeIdentifier same as BaseNuGetRuntimeIdentifier when set explicitly

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -70,6 +70,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)' == '' and '$(MSBuildProjectExtension)' != '.xproj'">true</ResolveNuGetPackages>
 
+    <!-- 
+    if BaseNuGetRuntimeIdentifier is defined then simply use it as RuntimeIdentifier, otherwise
+    we'll set RuntimeIdentifiers to default value later on.
+    -->
+    <RuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' != ''">$(BaseNuGetRuntimeIdentifier)</RuntimeIdentifier>
+
     <BaseNuGetRuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' == '' and '$(TargetPlatformIdentifier)' == 'UAP'">win10</BaseNuGetRuntimeIdentifier>
     <BaseNuGetRuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' == ''">win</BaseNuGetRuntimeIdentifier>
 


### PR DESCRIPTION
when BaseNuGetRuntimeIdentifier is set explicitly use that as RuntimeIdentifier instead of defining it to default values.

Fixes https://github.com/NuGet/Home/issues/4558

@rrelyea @tmeschter 