### PR TITLE
Add a missing scenario for Framework injection

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -284,6 +284,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_PackagingOutputsIncludesFramework Condition="'%(PackagingOutputs.FileName)%(PackagingOutputs.Extension)' == 'System.Runtime.dll'">true</_PackagingOutputsIncludesFramework>
       <_AppContainsManagedCodeForInjection Condition="'%(PackagingOutputs.Identity)' == '$(_TargetPlatformSdkDir)UnionMetadata\Windows.winmd'">true</_AppContainsManagedCodeForInjection>
+      <_AppContainsManagedCodeForInjection Condition="'%(PackagingOutputs.Identity)' == '$(WindowsSDK_UnionMetadataPath)\Windows.winmd'">true</_AppContainsManagedCodeForInjection>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Whenever a UWP app contains managed code we need to be sure to inject the .NET Core Framework assemblies. This is obviously the case when the app itself is written in C# or VB. However, we also need to handle the case where the app is written in C++ but references a WinRT component written in managed code.

We detect the latter case by looking for the use of the union Windows.winmd assembly. We assume the assembly is in a path that ends with "UnionMetadata\Windows.winmd", but this isn't always the case. Sometimes the path will include the Windows SDK version number, like "UnionMetadata\10.0.15000.0\Windows.winmd"; in this case we won't realize that the framework is needed, and .NET Native compilation will fail.

The fix here is to check for these other locations by making use of the WindowsSDK_UnionMetadataPath property.