### PR TITLE
Update Framework Injection check to support JavaScript UWP apps

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets
@@ -272,6 +272,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_PackagingOutputsIncludesFramework Condition="'%(PackagingOutputs.FileName)%(PackagingOutputs.Extension)' == 'System.Runtime.dll'">true</_PackagingOutputsIncludesFramework>
       <_AppContainsManagedCodeForInjection Condition="'%(PackagingOutputs.Identity)' == '$(_TargetPlatformSdkDir)UnionMetadata\Windows.winmd'">true</_AppContainsManagedCodeForInjection>
       <_AppContainsManagedCodeForInjection Condition="'%(PackagingOutputs.Identity)' == '$(WindowsSDK_UnionMetadataPath)\Windows.winmd'">true</_AppContainsManagedCodeForInjection>
+      <!-- In some scenarios (e.g. JavaScript UWP apps) the WindowsSDK_UnionMetadataPath may not be set. Check the target for completeness. -->
+      <_AppContainsManagedCodeForInjection Condition="'%(PackagingOutputs.TargetPath)' == '$(WinMetadataDir)\Windows.winmd'">true</_AppContainsManagedCodeForInjection>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Whenever a UWP app contains managed code we need to be sure to inject the .NET Core Framework assemblies. This is obviously the case when the app itself is written in C# or VB. However, we also need to handle the case where the app is written in JavaScript but references a WinRT component written in managed code.

Previously, this check was updated (for C++ apps) to look for the full location of the Windows.winmd file by using `WindowsSDK_UnionMetadataPath`. But this property is not always defined where we expect (e.g. in JavaScript UWP apps), and the condition can be modified to consider the “TargetPath” where the union is located.

Corresponding VS PR: [87422](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/87422?_a=overview)

**Customer scenario**

Customers debugging JavaScript UWP apps with a dependency on a Managed WinRT component are observing the Desktop CLR loaded, instead of CoreCLR. This is because expected Framework Injection is not happening due to a failing check.

**Bugs this fixes:** 

[445509](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/445509)

**Workarounds, if any**

N/A

**Risk**

Low, the change does not remove any of the existing checks

**Is this a regression from a previous update?**

No, I don't believe this has ever worked in VS2017

**Root cause analysis:**

[PR 60393](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/60393?_a=overview) extended framework injection to cover C++, but that approach did not work for JavaScript, and that was not considered at the time of the original fix.

**How was the bug found?**

Partner reported