### PR TITLE
Remove ImportAfter for NuGet.targets

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets
+++ b/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets
@@ -14,10 +14,4 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NuGetTargets Condition="'$(NuGetTargets)'==''">$(MSBuildExtensionsPath)\Microsoft\NuGet\$(VisualStudioVersion)\Microsoft.NuGet.targets</NuGetTargets>
   </PropertyGroup>
   <Import Condition="Exists('$(NuGetTargets)') and '$(SkipImportNuGetBuildTargets)' != 'true'" Project="$(NuGetTargets)" />
-
-  <!-- Import NuGet.targets for Restore -->
-  <PropertyGroup>
-    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildExtensionsPath)\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets</NuGetRestoreTargets>
-  </PropertyGroup>
-  <Import Condition="Exists('$(NuGetRestoreTargets)')" Project="$(NuGetRestoreTargets)" />
 </Project>


### PR DESCRIPTION
This would be taken in conjunction with https://github.com/Microsoft/msbuild/pull/2663
 * Stop relying on ImportAfter extension point to be included in MSBuild.
 * MSBuild to explicitly load NuGet.targets in the common targets.

Wasn't sure what to do about `Microsoft.NuGet.Solution.ImportAfter.targets`. I think it wouldn't be needed any longer, but I didn't see anything referring to the file. So let me know what I should do about that if we are going to take this. This and the MSBuild change will need to go together to CLI and VS to avoid double import warning.