### PR TITLE
Improving error messages for non project.json based projects

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Helpers/TempRoot.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Helpers/TempRoot.cs
@@ -54,9 +54,9 @@ namespace Microsoft.NuGet.Build.Tasks.Tests.Helpers
             return dir;
         }
 
-        public TempFile CreateFile(TempRoot root, string prefix = null, string extension = null, string directory = null, [CallerFilePath]string callerSourcePath = null, [CallerLineNumber]int callerLineNumber = 0)
+        public TempFile CreateFile(string prefix = null, string extension = null, string directory = null, [CallerFilePath]string callerSourcePath = null, [CallerLineNumber]int callerLineNumber = 0)
         {
-            return AddFile(new DisposableFile(root, prefix, extension, directory, callerSourcePath, callerLineNumber));
+            return AddFile(new DisposableFile(this, prefix, extension, directory, callerSourcePath, callerLineNumber));
         }
 
         public DisposableFile AddFile(DisposableFile file)

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.NuGet.Build.Tasks.Tests</RootNamespace>
     <AssemblyName>Microsoft.NuGet.Build.Tasks.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SignAssembly>true</SignAssembly>
@@ -72,7 +72,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Json\analyzers.json" />
     <None Include="Json\FluentAssertions.lock.json" />
     <None Include="Json\FluentAssertionsAndWin10.lock.json" />
@@ -83,7 +85,6 @@
     <None Include="Json\Win10.Edm.json" />
     <None Include="Json\Win10.json" />
     <None Include="Json\Win10.xunit.json" />
-    <None Include="project.json" />
     <None Include="Json\ProjectDependency.assets.json" />
     <None Include="ProjectReferences\LockFileMissingMSBuildProjectThatProvidesAssets.json" />
     <None Include="ProjectReferences\LockFileWithCSProjReference.json" />
@@ -100,6 +101,19 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NuGet.ProjectModel">
+      <Version>4.7.0</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.3.1</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.3.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>Microsoft.NuGet.Build.Tasks.Tests</RootNamespace>
     <AssemblyName>Microsoft.NuGet.Build.Tasks.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/Microsoft.NuGet.Build.Tasks.Tests.csproj
@@ -10,7 +10,6 @@
     <RootNamespace>Microsoft.NuGet.Build.Tasks.Tests</RootNamespace>
     <AssemblyName>Microsoft.NuGet.Build.Tasks.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-    <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/NuGetTestHelpers.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/NuGetTestHelpers.cs
@@ -7,8 +7,6 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Microsoft.NuGet.Build.Tasks;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Microsoft.NuGet.Build.Tasks.Tests.Helpers;
@@ -21,6 +19,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
             string projectLockJsonFileContents,
             string targetMoniker,
             string runtimeIdentifier,
+            bool isLockFileProjectJsonBased = true,
             string projectLanguage = null,
             bool allowFallbackOnTargetSelection = false,
             TryGetRuntimeVersion tryGetRuntimeVersion = null,
@@ -33,7 +32,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
             {
                 var projectDirectory = rootDirectory.CreateDirectory();
 
-                var projectLockJsonFile = projectDirectory.CreateFile("project.lock.json");
+                var projectLockJsonFile = projectDirectory.CreateFile(isLockFileProjectJsonBased ? "project.lock.json" : "project.assets.json");
                 projectLockJsonFile.WriteAllText(projectLockJsonFileContents);
 
                 if (projectJsonFileContents != null)

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ProjectReferences/Resources.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ProjectReferences/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests.ProjectReferences {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                     runtimeIdentifier: "missing-runtime-identifier",
                     allowFallbackOnTargetSelection: false));
 
-            Assert.Equal(nameof(Strings.MissingRuntimeInRuntimesSection), exception.ResourceName);
+            Assert.Equal(nameof(Strings.MissingRuntimeInProjectJson), exception.ResourceName);
             Assert.Equal(new[] { "missing-runtime-identifier", "\"missing-runtime-identifier\": { }" }, exception.MessageArgs);
         }
 
@@ -103,7 +103,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                     allowFallbackOnTargetSelection: false,
                     projectJsonFileContents: "{ }"));
 
-            Assert.Equal(nameof(Strings.MissingRuntimesSection), exception.ResourceName);
+            Assert.Equal(nameof(Strings.MissingRuntimesSectionInProjectJson), exception.ResourceName);
             Assert.Equal(new[] { "\"runtimes\": { \"missing-runtime-identifier\": { } }" }, exception.MessageArgs);
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                     runtimeIdentifier: "missing-runtime-identifier",
                     allowFallbackOnTargetSelection: false));
 
-            Assert.Equal(nameof(Strings.MissingFramework), exception.ResourceName);
+            Assert.Equal(nameof(Strings.MissingFrameworkInProjectJson), exception.ResourceName);
             Assert.Equal(new[] { "Missing,Version=1.0" }, exception.MessageArgs);
         }
 

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/ReferenceResolutionTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                     allowFallbackOnTargetSelection: false,
                     isLockFileProjectJsonBased: false));
 
-                Assert.Equal(nameof(Strings.MissingRuntimeIdentifierInCsproj), exception.ResourceName);
+                Assert.Equal(nameof(Strings.MissingRuntimeIdentifierInProjectFile), exception.ResourceName);
                 Assert.Equal(new[] { "missing-runtime-identifier", "missing-runtime-identifier" }, exception.MessageArgs);
             }
         }
@@ -184,7 +184,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
                         allowFallbackOnTargetSelection: false,
                         isLockFileProjectJsonBased: false));
 
-                Assert.Equal(nameof(Strings.MissingFrameworkInCsproj), exception.ResourceName);
+                Assert.Equal(nameof(Strings.MissingFrameworkInProjectFile), exception.ResourceName);
                 Assert.Equal(new[] { "Missing,Version=1.0" }, exception.MessageArgs);
             }
         }
@@ -228,7 +228,7 @@ namespace Microsoft.NuGet.Build.Tasks.Tests
 
         [Theory]
         [InlineData(true, nameof(Strings.NoTargetsInLockFileForProjectJson))]
-        [InlineData(false, nameof(Strings.NoTargetsInLockFileForCsproj))]
+        [InlineData(false, nameof(Strings.NoTargetsInLockFileForProjectFile))]
         public static void TestReferenceResolutionWithMissingTargets(bool isProjectJsonBased, string errorResourceName)
         {
             var lockFile = GenerateLockFileWithoutTarget();

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/app.config
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/app.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
     <add key="xunit.shadowCopy" value="false"/>
   </appSettings>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>

--- a/src/Microsoft.NuGet.Build.Tasks.Tests/project.json
+++ b/src/Microsoft.NuGet.Build.Tasks.Tests/project.json
@@ -1,8 +1,0 @@
-﻿{
-  "dependencies": {
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
-  },
-  "frameworks": { "net45": { } },
-  "runtimes": { "win": { } }
-}

--- a/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -217,7 +217,11 @@ namespace Microsoft.NuGet.Build.Tasks
         {
             if (!_fileExists(ProjectLockFile))
             {
-                throw new ExceptionFromResource(nameof(Strings.LockFileNotFound), ProjectLockFile);
+                var errorMessage = IsLockFileProjectJsonBased(ProjectLockFile) ?
+                    nameof(Strings.LockFileNotFoundForProjectJson) :
+                    nameof(Strings.LockFileNotFoundForProjectFile);
+
+                throw new ExceptionFromResource(errorMessage, ProjectLockFile);
             }
 
             JObject lockFile;
@@ -719,7 +723,7 @@ namespace Microsoft.NuGet.Build.Tasks
         {
             var noTargetsInLockFileErrorString = IsLockFileProjectJsonBased(ProjectLockFile) ?
                 nameof(Strings.NoTargetsInLockFileForProjectJson) :
-                nameof(Strings.NoTargetsInLockFileForCsproj);
+                nameof(Strings.NoTargetsInLockFileForProjectFile);
 
             throw new ExceptionFromResource(noTargetsInLockFileErrorString);
         }
@@ -728,8 +732,8 @@ namespace Microsoft.NuGet.Build.Tasks
         {
             var runtimePiece = RuntimeIdentifier;
             var runtimesSection = $"<{RuntimeIdentifiersProperty}>{RuntimeIdentifier}</{RuntimeIdentifiersProperty}>";
-            var missingRuntimeInRuntimesErrorString = nameof(Strings.MissingRuntimeIdentifierInCsproj);
-            var missingRuntimesErrorString = nameof(Strings.MissingRuntimeIdentifierPropertyInCsproj);
+            var missingRuntimeInRuntimesErrorString = nameof(Strings.MissingRuntimeIdentifierInProjectFile);
+            var missingRuntimesErrorString = nameof(Strings.MissingRuntimeIdentifierPropertyInProjectFile);
 
             if (IsLockFileProjectJsonBased(ProjectLockFile))
             {
@@ -772,7 +776,7 @@ namespace Microsoft.NuGet.Build.Tasks
         {
             var missingFrameworkErrorString = IsLockFileProjectJsonBased(ProjectLockFile) ?
                 nameof(Strings.MissingFrameworkInProjectJson) :
-                nameof(Strings.MissingFrameworkInCsproj);
+                nameof(Strings.MissingFrameworkInProjectFile);
 
             ThrowExceptionIfNotAllowingFallback(missingFrameworkErrorString, TargetMonikers.First().ItemSpec);
         }
@@ -987,7 +991,11 @@ namespace Microsoft.NuGet.Build.Tasks
 
                 if (libraryObject == null)
                 {
-                    throw new ExceptionFromResource(nameof(Strings.MissingPackageInTargetsSection), package.Key);
+                    var errorMessage = IsLockFileProjectJsonBased(ProjectLockFile) ? 
+                        nameof(Strings.MissingPackageInTargetsForProjectJson) : 
+                        nameof(Strings.MissingPackageInTargetsSectionForProjectFile);
+
+                    throw new ExceptionFromResource(errorMessage, package.Key);
                 }
 
                 // If this is a project then we need to figure out it's relative output path

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
@@ -79,16 +79,25 @@ namespace Microsoft.NuGet.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project is not referencing the &quot;{0}&quot; framework. Add a reference to &quot;{0}&quot; in the &quot;frameworks&quot; section of your project.json, and then re-run NuGet restore..
+        ///   Looks up a localized string similar to Your project does not reference &quot;{0}&quot; framework. Add a reference to &quot;{0}&quot; in the &quot;TargetFrameworks&quot; property of your project csproj file and then re-run NuGet restore..
         /// </summary>
-        internal static string MissingFramework {
+        internal static string MissingFrameworkInCsproj {
             get {
-                return ResourceManager.GetString("MissingFramework", resourceCulture);
+                return ResourceManager.GetString("MissingFrameworkInCsproj", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project is consuming assets from the project &apos;{0}&apos; but no MSBuild project is found in the project.lock.json. Check the project references in your project file, and re-run NuGet restore..
+        ///   Looks up a localized string similar to Your project does not reference &quot;{0}&quot; framework. Add a reference to &quot;{0}&quot; in the &quot;frameworks&quot; section of your project.json and then re-run NuGet restore..
+        /// </summary>
+        internal static string MissingFrameworkInProjectJson {
+            get {
+                return ResourceManager.GetString("MissingFrameworkInProjectJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project is consuming assets from the project &apos;{0}&apos; but no MSBuild project is found in the project lock file. Check the project references in your project csproj file  and re-run NuGet restore..
         /// </summary>
         internal static string MissingMSBuildPathInProjectPackage {
             get {
@@ -106,56 +115,56 @@ namespace Microsoft.NuGet.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project.json is referencing the project &apos;{0}&apos;, but an output path was not specified on an item in the {1} property..
+        ///   Looks up a localized string similar to Your project csproj file doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; to the &quot;RuntimeIdentifiers&quot; property in your project csproj file and then re-run NuGet restore..
         /// </summary>
-        internal static string MissingProjectReference {
+        internal static string MissingRuntimeIdentifierInCsproj {
             get {
-                return ResourceManager.GetString("MissingProjectReference", resourceCulture);
+                return ResourceManager.GetString("MissingRuntimeIdentifierInCsproj", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Your project csproj file doesn&apos;t have the &quot;RuntimeIdentifiers&quot; property. You should add &apos;{0}&apos; to your project csproj file and then re-run NuGet restore..
         /// </summary>
-        internal static string MissingRuntimeIdentifiers {
+        internal static string MissingRuntimeIdentifiersInCsproj {
             get {
-                return ResourceManager.GetString("MissingRuntimeIdentifiers", resourceCulture);
+                return ResourceManager.GetString("MissingRuntimeIdentifiersInCsproj", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project.json doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; inside your &quot;runtimes&quot; section in your project.json, and then re-run NuGet restore..
+        ///   Looks up a localized string similar to Your project.json doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; inside your &quot;runtimes&quot; section in your project.json and then re-run NuGet restore..
         /// </summary>
-        internal static string MissingRuntimeInRuntimesSection {
+        internal static string MissingRuntimeInProjectJson {
             get {
-                return ResourceManager.GetString("MissingRuntimeInRuntimesSection", resourceCulture);
+                return ResourceManager.GetString("MissingRuntimeInProjectJson", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Your project.json doesn&apos;t have a runtimes section. You should add &apos;{0}&apos; to your project.json and then re-run NuGet restore..
         /// </summary>
-        internal static string MissingRuntimesSection {
+        internal static string MissingRuntimesSectionInProjectJson {
             get {
-                return ResourceManager.GetString("MissingRuntimesSection", resourceCulture);
+                return ResourceManager.GetString("MissingRuntimesSectionInProjectJson", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project csproj file doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; to the &quot;RuntimeIdentifiers&quot; property in your project csproj file and then re-run NuGet restore..
+        ///   Looks up a localized string similar to No targets could be found in the lock file. Make sure you have &quot;RuntimeIdentifiers&quot; property in your project csproj file..
         /// </summary>
-        internal static string MissingSpecificRuntimeIdentifier {
+        internal static string NoTargetsInLockFileForCsproj {
             get {
-                return ResourceManager.GetString("MissingSpecificRuntimeIdentifier", resourceCulture);
+                return ResourceManager.GetString("NoTargetsInLockFileForCsproj", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No targets could be found in the lock file. Make sure you have a supports or runtimes section i your project.json file..
+        ///   Looks up a localized string similar to No targets could be found in the lock file. Make sure you have a supports or runtimes section in your project.json file..
         /// </summary>
-        internal static string NoTargetsInLockFile {
+        internal static string NoTargetsInLockFileForProjectJson {
             get {
-                return ResourceManager.GetString("NoTargetsInLockFile", resourceCulture);
+                return ResourceManager.GetString("NoTargetsInLockFileForProjectJson", resourceCulture);
             }
         }
         

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
@@ -126,9 +126,9 @@ namespace Microsoft.NuGet.Build.Tasks {
         /// <summary>
         ///   Looks up a localized string similar to Your project csproj file doesn&apos;t have the &quot;RuntimeIdentifiers&quot; property. You should add &apos;{0}&apos; to your project csproj file and then re-run NuGet restore..
         /// </summary>
-        internal static string MissingRuntimeIdentifiersInCsproj {
+        internal static string MissingRuntimeIdentifierPropertyInCsproj {
             get {
-                return ResourceManager.GetString("MissingRuntimeIdentifiersInCsproj", resourceCulture);
+                return ResourceManager.GetString("MissingRuntimeIdentifierPropertyInCsproj", resourceCulture);
             }
         }
         

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NuGet.Build.Tasks {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -115,6 +115,15 @@ namespace Microsoft.NuGet.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your project csproj file doesn&apos;t have the &quot;RuntimeIdentifiers&quot; property. You should add &apos;{0}&apos; to your project csproj file and then re-run NuGet restore..
+        /// </summary>
+        internal static string MissingRuntimeIdentifiers {
+            get {
+                return ResourceManager.GetString("MissingRuntimeIdentifiers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Your project.json doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; inside your &quot;runtimes&quot; section in your project.json, and then re-run NuGet restore..
         /// </summary>
         internal static string MissingRuntimeInRuntimesSection {
@@ -129,6 +138,15 @@ namespace Microsoft.NuGet.Build.Tasks {
         internal static string MissingRuntimesSection {
             get {
                 return ResourceManager.GetString("MissingRuntimesSection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project csproj file doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; to the &quot;RuntimeIdentifiers&quot; property in your project csproj file and then re-run NuGet restore..
+        /// </summary>
+        internal static string MissingSpecificRuntimeIdentifier {
+            get {
+                return ResourceManager.GetString("MissingSpecificRuntimeIdentifier", resourceCulture);
             }
         }
         

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.Designer.cs
@@ -70,20 +70,29 @@ namespace Microsoft.NuGet.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lock file {0} couldn&apos;t be found. Run a NuGet package restore to generate this file..
+        ///   Looks up a localized string similar to Assets file {0} couldn&apos;t be found. Run a NuGet package restore to generate this file..
         /// </summary>
-        internal static string LockFileNotFound {
+        internal static string LockFileNotFoundForProjectFile {
             get {
-                return ResourceManager.GetString("LockFileNotFound", resourceCulture);
+                return ResourceManager.GetString("LockFileNotFoundForProjectFile", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project does not reference &quot;{0}&quot; framework. Add a reference to &quot;{0}&quot; in the &quot;TargetFrameworks&quot; property of your project csproj file and then re-run NuGet restore..
+        ///   Looks up a localized string similar to Lock file {0} couldn&apos;t be found. Run a NuGet package restore to generate this file..
         /// </summary>
-        internal static string MissingFrameworkInCsproj {
+        internal static string LockFileNotFoundForProjectJson {
             get {
-                return ResourceManager.GetString("MissingFrameworkInCsproj", resourceCulture);
+                return ResourceManager.GetString("LockFileNotFoundForProjectJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project does not reference &quot;{0}&quot; framework. Add a reference to &quot;{0}&quot; in the &quot;TargetFrameworks&quot; property of your project file and then re-run NuGet restore..
+        /// </summary>
+        internal static string MissingFrameworkInProjectFile {
+            get {
+                return ResourceManager.GetString("MissingFrameworkInProjectFile", resourceCulture);
             }
         }
         
@@ -97,43 +106,43 @@ namespace Microsoft.NuGet.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project is consuming assets from the project &apos;{0}&apos; but no MSBuild project is found in the project lock file. Check the project references in your project csproj file  and re-run NuGet restore..
-        /// </summary>
-        internal static string MissingMSBuildPathInProjectPackage {
-            get {
-                return ResourceManager.GetString("MissingMSBuildPathInProjectPackage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The package &apos;{0}&apos; could not be found in the libraries section of the lock file. This may indicate your lock file is corrupted..
         /// </summary>
-        internal static string MissingPackageInTargetsSection {
+        internal static string MissingPackageInTargetsForProjectJson {
             get {
-                return ResourceManager.GetString("MissingPackageInTargetsSection", resourceCulture);
+                return ResourceManager.GetString("MissingPackageInTargetsForProjectJson", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project csproj file doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; to the &quot;RuntimeIdentifiers&quot; property in your project csproj file and then re-run NuGet restore..
+        ///   Looks up a localized string similar to The package &apos;{0}&apos; could not be found in the libraries section of the assets file. This may indicate your assets file is corrupted..
         /// </summary>
-        internal static string MissingRuntimeIdentifierInCsproj {
+        internal static string MissingPackageInTargetsSectionForProjectFile {
             get {
-                return ResourceManager.GetString("MissingRuntimeIdentifierInCsproj", resourceCulture);
+                return ResourceManager.GetString("MissingPackageInTargetsSectionForProjectFile", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project csproj file doesn&apos;t have the &quot;RuntimeIdentifiers&quot; property. You should add &apos;{0}&apos; to your project csproj file and then re-run NuGet restore..
+        ///   Looks up a localized string similar to Your project file doesn&apos;t list &apos;{0}&apos; as a &quot;RuntimeIdentifier&quot;. You should add &apos;{1}&apos; to the &quot;RuntimeIdentifiers&quot; property in your project file and then re-run NuGet restore..
         /// </summary>
-        internal static string MissingRuntimeIdentifierPropertyInCsproj {
+        internal static string MissingRuntimeIdentifierInProjectFile {
             get {
-                return ResourceManager.GetString("MissingRuntimeIdentifierPropertyInCsproj", resourceCulture);
+                return ResourceManager.GetString("MissingRuntimeIdentifierInProjectFile", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your project.json doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; inside your &quot;runtimes&quot; section in your project.json and then re-run NuGet restore..
+        ///   Looks up a localized string similar to Your project file doesn&apos;t have the &quot;RuntimeIdentifiers&quot; property. You should add &apos;{0}&apos; to your project file and then re-run NuGet restore..
+        /// </summary>
+        internal static string MissingRuntimeIdentifierPropertyInProjectFile {
+            get {
+                return ResourceManager.GetString("MissingRuntimeIdentifierPropertyInProjectFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project.json doesn&apos;t list &apos;{0}&apos; as a &quot;RuntimeIdentifier&quot;. You should add &apos;{1}&apos; inside your &quot;runtimes&quot; section in your project.json and then re-run NuGet restore..
         /// </summary>
         internal static string MissingRuntimeInProjectJson {
             get {
@@ -151,11 +160,11 @@ namespace Microsoft.NuGet.Build.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No targets could be found in the lock file. Make sure you have &quot;RuntimeIdentifiers&quot; property in your project csproj file..
+        ///   Looks up a localized string similar to No targets could be found in the assets file. Make sure you have &quot;RuntimeIdentifiers&quot; property in your project file..
         /// </summary>
-        internal static string NoTargetsInLockFileForCsproj {
+        internal static string NoTargetsInLockFileForProjectFile {
             get {
-                return ResourceManager.GetString("NoTargetsInLockFileForCsproj", resourceCulture);
+                return ResourceManager.GetString("NoTargetsInLockFileForProjectFile", resourceCulture);
             }
         }
         

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -122,44 +122,48 @@
     <comment>0 token 
 1 - chosen value</comment>
   </data>
-  <data name="LockFileNotFound" xml:space="preserve">
-    <value>Lock file {0} couldn't be found. Run a NuGet package restore to generate this file.</value>
-    <comment>0 - lock file</comment>
+  <data name="LockFileNotFoundForProjectFile" xml:space="preserve">
+    <value>Assets file {0} couldn't be found. Run a NuGet package restore to generate this file.</value>
+    <comment>0 - assets file path</comment>
   </data>
-  <data name="MissingFrameworkInCsproj" xml:space="preserve">
-    <value>Your project does not reference "{0}" framework. Add a reference to "{0}" in the "TargetFrameworks" property of your project csproj file and then re-run NuGet restore.</value>
+  <data name="LockFileNotFoundForProjectJson" xml:space="preserve">
+    <value>Lock file {0} couldn't be found. Run a NuGet package restore to generate this file.</value>
+    <comment>0 - lock file path</comment>
+  </data>
+  <data name="MissingFrameworkInProjectFile" xml:space="preserve">
+    <value>Your project does not reference "{0}" framework. Add a reference to "{0}" in the "TargetFrameworks" property of your project file and then re-run NuGet restore.</value>
     <comment>0 - target framework</comment>
   </data>
   <data name="MissingFrameworkInProjectJson" xml:space="preserve">
     <value>Your project does not reference "{0}" framework. Add a reference to "{0}" in the "frameworks" section of your project.json and then re-run NuGet restore.</value>
     <comment>0 - target framework</comment>
   </data>
-  <data name="MissingMSBuildPathInProjectPackage" xml:space="preserve">
-    <value>Your project is consuming assets from the project '{0}' but no MSBuild project is found in the project lock file. Check the project references in your project csproj file  and re-run NuGet restore.</value>
-    <comment>0 - project name</comment>
-  </data>
-  <data name="MissingPackageInTargetsSection" xml:space="preserve">
+  <data name="MissingPackageInTargetsForProjectJson" xml:space="preserve">
     <value>The package '{0}' could not be found in the libraries section of the lock file. This may indicate your lock file is corrupted.</value>
     <comment>0 package id</comment>
   </data>
-  <data name="MissingRuntimeIdentifierInCsproj" xml:space="preserve">
-    <value>Your project csproj file doesn't list '{0}' as a targeted runtime. You should add '{1}' to the "RuntimeIdentifiers" property in your project csproj file and then re-run NuGet restore.</value>
+  <data name="MissingPackageInTargetsSectionForProjectFile" xml:space="preserve">
+    <value>The package '{0}' could not be found in the libraries section of the assets file. This may indicate your assets file is corrupted.</value>
+    <comment>0 package id</comment>
+  </data>
+  <data name="MissingRuntimeIdentifierInProjectFile" xml:space="preserve">
+    <value>Your project file doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' to the "RuntimeIdentifiers" property in your project file and then re-run NuGet restore.</value>
     <comment>0 &amp;1 - Runtime Identifier</comment>
   </data>
-  <data name="MissingRuntimeIdentifierPropertyInCsproj" xml:space="preserve">
-    <value>Your project csproj file doesn't have the "RuntimeIdentifiers" property. You should add '{0}' to your project csproj file and then re-run NuGet restore.</value>
+  <data name="MissingRuntimeIdentifierPropertyInProjectFile" xml:space="preserve">
+    <value>Your project file doesn't have the "RuntimeIdentifiers" property. You should add '{0}' to your project file and then re-run NuGet restore.</value>
     <comment>0 - Runtime Identifier</comment>
   </data>
   <data name="MissingRuntimeInProjectJson" xml:space="preserve">
-    <value>Your project.json doesn't list '{0}' as a targeted runtime. You should add '{1}' inside your "runtimes" section in your project.json and then re-run NuGet restore.</value>
+    <value>Your project.json doesn't list '{0}' as a "RuntimeIdentifier". You should add '{1}' inside your "runtimes" section in your project.json and then re-run NuGet restore.</value>
     <comment>0 - Runtime Identifier</comment>
   </data>
   <data name="MissingRuntimesSectionInProjectJson" xml:space="preserve">
     <value>Your project.json doesn't have a runtimes section. You should add '{0}' to your project.json and then re-run NuGet restore.</value>
     <comment>0 - Runtime Identifier</comment>
   </data>
-  <data name="NoTargetsInLockFileForCsproj" xml:space="preserve">
-    <value>No targets could be found in the lock file. Make sure you have "RuntimeIdentifiers" property in your project csproj file.</value>
+  <data name="NoTargetsInLockFileForProjectFile" xml:space="preserve">
+    <value>No targets could be found in the assets file. Make sure you have "RuntimeIdentifiers" property in your project file.</value>
   </data>
   <data name="NoTargetsInLockFileForProjectJson" xml:space="preserve">
     <value>No targets could be found in the lock file. Make sure you have a supports or runtimes section in your project.json file.</value>

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -146,7 +146,7 @@
     <value>Your project csproj file doesn't list '{0}' as a targeted runtime. You should add '{1}' to the "RuntimeIdentifiers" property in your project csproj file and then re-run NuGet restore.</value>
     <comment>0 &amp;1 - Runtime Identifier</comment>
   </data>
-  <data name="MissingRuntimeIdentifiersInCsproj" xml:space="preserve">
+  <data name="MissingRuntimeIdentifierPropertyInCsproj" xml:space="preserve">
     <value>Your project csproj file doesn't have the "RuntimeIdentifiers" property. You should add '{0}' to your project csproj file and then re-run NuGet restore.</value>
     <comment>0 - Runtime Identifier</comment>
   </data>

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -119,46 +119,63 @@
   </resheader>
   <data name="DuplicatePreprocessorToken" xml:space="preserve">
     <value>The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</value>
+    <comment>0 token 
+1 - chosen value</comment>
   </data>
   <data name="LockFileNotFound" xml:space="preserve">
     <value>Lock file {0} couldn't be found. Run a NuGet package restore to generate this file.</value>
+    <comment>0 - lock file</comment>
   </data>
-  <data name="MissingFramework" xml:space="preserve">
-    <value>Your project is not referencing the "{0}" framework. Add a reference to "{0}" in the "frameworks" section of your project.json, and then re-run NuGet restore.</value>
+  <data name="MissingFrameworkInCsproj" xml:space="preserve">
+    <value>Your project does not reference "{0}" framework. Add a reference to "{0}" in the "TargetFrameworks" property of your project csproj file and then re-run NuGet restore.</value>
+    <comment>0 - target framework</comment>
+  </data>
+  <data name="MissingFrameworkInProjectJson" xml:space="preserve">
+    <value>Your project does not reference "{0}" framework. Add a reference to "{0}" in the "frameworks" section of your project.json and then re-run NuGet restore.</value>
+    <comment>0 - target framework</comment>
   </data>
   <data name="MissingMSBuildPathInProjectPackage" xml:space="preserve">
-    <value>Your project is consuming assets from the project '{0}' but no MSBuild project is found in the project.lock.json. Check the project references in your project file, and re-run NuGet restore.</value>
+    <value>Your project is consuming assets from the project '{0}' but no MSBuild project is found in the project lock file. Check the project references in your project csproj file  and re-run NuGet restore.</value>
+    <comment>0 - project name</comment>
   </data>
   <data name="MissingPackageInTargetsSection" xml:space="preserve">
     <value>The package '{0}' could not be found in the libraries section of the lock file. This may indicate your lock file is corrupted.</value>
+    <comment>0 package id</comment>
   </data>
-  <data name="MissingProjectReference" xml:space="preserve">
-    <value>The project.json is referencing the project '{0}', but an output path was not specified on an item in the {1} property.</value>
-  </data>
-  <data name="MissingRuntimeIdentifiers" xml:space="preserve">
-    <value>Your project csproj file doesn't have the "RuntimeIdentifiers" property. You should add '{0}' to your project csproj file and then re-run NuGet restore.</value>
-    <comment>0 - RID</comment>
-  </data>
-  <data name="MissingRuntimeInRuntimesSection" xml:space="preserve">
-    <value>Your project.json doesn't list '{0}' as a targeted runtime. You should add '{1}' inside your "runtimes" section in your project.json, and then re-run NuGet restore.</value>
-  </data>
-  <data name="MissingRuntimesSection" xml:space="preserve">
-    <value>Your project.json doesn't have a runtimes section. You should add '{0}' to your project.json and then re-run NuGet restore.</value>
-  </data>
-  <data name="MissingSpecificRuntimeIdentifier" xml:space="preserve">
+  <data name="MissingRuntimeIdentifierInCsproj" xml:space="preserve">
     <value>Your project csproj file doesn't list '{0}' as a targeted runtime. You should add '{1}' to the "RuntimeIdentifiers" property in your project csproj file and then re-run NuGet restore.</value>
-    <comment>0/1 - RID</comment>
+    <comment>0 &amp;1 - Runtime Identifier</comment>
   </data>
-  <data name="NoTargetsInLockFile" xml:space="preserve">
-    <value>No targets could be found in the lock file. Make sure you have a supports or runtimes section i your project.json file.</value>
+  <data name="MissingRuntimeIdentifiersInCsproj" xml:space="preserve">
+    <value>Your project csproj file doesn't have the "RuntimeIdentifiers" property. You should add '{0}' to your project csproj file and then re-run NuGet restore.</value>
+    <comment>0 - Runtime Identifier</comment>
+  </data>
+  <data name="MissingRuntimeInProjectJson" xml:space="preserve">
+    <value>Your project.json doesn't list '{0}' as a targeted runtime. You should add '{1}' inside your "runtimes" section in your project.json and then re-run NuGet restore.</value>
+    <comment>0 - Runtime Identifier</comment>
+  </data>
+  <data name="MissingRuntimesSectionInProjectJson" xml:space="preserve">
+    <value>Your project.json doesn't have a runtimes section. You should add '{0}' to your project.json and then re-run NuGet restore.</value>
+    <comment>0 - Runtime Identifier</comment>
+  </data>
+  <data name="NoTargetsInLockFileForCsproj" xml:space="preserve">
+    <value>No targets could be found in the lock file. Make sure you have "RuntimeIdentifiers" property in your project csproj file.</value>
+  </data>
+  <data name="NoTargetsInLockFileForProjectJson" xml:space="preserve">
+    <value>No targets could be found in the lock file. Make sure you have a supports or runtimes section in your project.json file.</value>
   </data>
   <data name="PackageFolderNotFound" xml:space="preserve">
     <value>The package {0} with version {1} could not be found in {2}. Run a NuGet package restore to download the package.</value>
+    <comment>0 - package id
+1 - package version 
+2 - package folder path</comment>
   </data>
   <data name="PreprocessedDirectoryNotSet" xml:space="preserve">
     <value>The {0} property must be set in order to consume preprocessed content.</value>
+    <comment>0 - directory path</comment>
   </data>
   <data name="UnspecifiedToken" xml:space="preserve">
     <value>The token '{0}' is unrecognized.</value>
+    <comment>0 - token</comment>
   </data>
 </root>

--- a/src/Microsoft.NuGet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.NuGet.Build.Tasks/Strings.resx
@@ -135,11 +135,19 @@
   <data name="MissingProjectReference" xml:space="preserve">
     <value>The project.json is referencing the project '{0}', but an output path was not specified on an item in the {1} property.</value>
   </data>
+  <data name="MissingRuntimeIdentifiers" xml:space="preserve">
+    <value>Your project csproj file doesn't have the "RuntimeIdentifiers" property. You should add '{0}' to your project csproj file and then re-run NuGet restore.</value>
+    <comment>0 - RID</comment>
+  </data>
   <data name="MissingRuntimeInRuntimesSection" xml:space="preserve">
     <value>Your project.json doesn't list '{0}' as a targeted runtime. You should add '{1}' inside your "runtimes" section in your project.json, and then re-run NuGet restore.</value>
   </data>
   <data name="MissingRuntimesSection" xml:space="preserve">
     <value>Your project.json doesn't have a runtimes section. You should add '{0}' to your project.json and then re-run NuGet restore.</value>
+  </data>
+  <data name="MissingSpecificRuntimeIdentifier" xml:space="preserve">
+    <value>Your project csproj file doesn't list '{0}' as a targeted runtime. You should add '{1}' to the "RuntimeIdentifiers" property in your project csproj file and then re-run NuGet restore.</value>
+    <comment>0/1 - RID</comment>
   </data>
   <data name="NoTargetsInLockFile" xml:space="preserve">
     <value>No targets could be found in the lock file. Make sure you have a supports or runtimes section i your project.json file.</value>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/6959

This PR improves the error experience for non project.json based projects. Primarily improves the error message for missing RID from - 

`
 C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets(186,5): 
error : 
Your project.json doesn't have a runtimes section. You should add '"runtimes": { "win": { } }' to your
 project.json and then re-run NuGet restore.
`

to - 

`
C:\Program Files (x86)\Microsoft Visual Studio\2017Stable\Enterprise\MSBuild\Microsoft\NuGet\15.0\Microsoft.NuGet.targets(186,5): error : 
Your project csproj file doesn't list 'win' as a targeted runtime. You should add 'win' to the "RuntimeIdentifiers" property in your project csproj file and the n re-run NuGet restore. [E:\NuGet.BuildTasks\src\Microsoft.NuGet.Build.Tasks.Tests\Microsoft.NuGet.Build.Tasks.Tests.csproj]
`

Plus addimng tests for non project.json based scenarios. 